### PR TITLE
#26: parse errors as we currently expect them (closes #26)

### DIFF
--- a/test/expected-route3.txt
+++ b/test/expected-route3.txt
@@ -19,6 +19,15 @@ export function unsafeValidate<S, A>(value: any, type: t.Type<S, A>): A {
   return value as A
 }
 
+const parseError = (err: any) => {
+  try {
+    const { errors = [] } = JSON.parse(err.response.data);
+    return Promise.reject({ status: err.response.status, errors });
+  } catch (e) {
+    return Promise.reject({ status: err && err.response && err.response.status || 0, errors: [] });
+  }
+};
+
 export default function getRoutes(config: RouteConfig) {
   return {
     /** Create a new search query for available vehicles */
@@ -36,7 +45,7 @@ export default function getRoutes(config: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: config.timeout
-      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.UUID)) as any
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.UUID), parseError) as any
     },
 
     /** Returns an existing query for available vehicles */
@@ -56,7 +65,7 @@ export default function getRoutes(config: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: config.timeout
-      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.AvailableVehicleSearchQuery)) as any
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.AvailableVehicleSearchQuery), parseError) as any
     },
 
     /** Returns the resulting available vehicles for the created query */
@@ -76,7 +85,7 @@ export default function getRoutes(config: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: config.timeout
-      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.AvailableVehicleSearchResult)) as any
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.AvailableVehicleSearchResult), parseError) as any
     },
 
     /** Updates the selected SpecialEquipments for the specified AvailableVehicle */
@@ -95,7 +104,7 @@ export default function getRoutes(config: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: config.timeout
-      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.UUID)) as any
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.UUID), parseError) as any
     },
 
     /** Returns the specified available vehicle */
@@ -115,7 +124,7 @@ export default function getRoutes(config: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: config.timeout
-      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.AvailableVehicle)) as any
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.AvailableVehicle), parseError) as any
     },
 
     /** Search locations */
@@ -135,7 +144,7 @@ export default function getRoutes(config: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: config.timeout
-      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.LocationSearchResult)) as any
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.LocationSearchResult), parseError) as any
     },
 
     /** Get available SpecialEquipment for a given pickUp Location and rental duration */
@@ -156,7 +165,7 @@ export default function getRoutes(config: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: config.timeout
-      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), t.array(m.AvailableSpecialEquipment))) as any
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), t.array(m.AvailableSpecialEquipment)), parseError) as any
     },
 
     /** log a user in */
@@ -172,7 +181,7 @@ export default function getRoutes(config: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: config.timeout
-      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.API_UserAuthCredentials)) as any
+      }).then(res => unsafeValidate(config.unwrapApiResponse(res.data), m.API_UserAuthCredentials), parseError) as any
     }
   }
 }


### PR DESCRIPTION
Closes #26

## Test Plan

### tests performed
tested manually on alinitypro: previously, network errors had no effects (no error modal shown) because the switch on `status` didn't match anything. With this version the error modals are shown again

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
