### PR TITLE
#27: deserialize api values also in production (closes #27)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,12 +262,9 @@ interface RouteConfig {
 
 import { failure } from 'io-ts/lib/PathReporter'
 export function unsafeValidate<S, A>(value: any, type: t.Type<S, A>): A {
-  if (process.env.NODE_ENV !== 'production') {
-    return t.validate(value, type).fold(errors => {
-      throw new Error(failure(errors).join('\\n'))
-    }, t.identity)
-  }
-  return value as A
+  return t.validate(value, type).fold(errors => {
+    throw new Error(failure(errors).join('\\n'))
+  }, t.identity)
 }
 
 const parseError = (err: any) => {

--- a/test/expected-route3.txt
+++ b/test/expected-route3.txt
@@ -11,12 +11,9 @@ interface RouteConfig {
 
 import { failure } from 'io-ts/lib/PathReporter'
 export function unsafeValidate<S, A>(value: any, type: t.Type<S, A>): A {
-  if (process.env.NODE_ENV !== 'production') {
-    return t.validate(value, type).fold(errors => {
-      throw new Error(failure(errors).join('\n'))
-    }, t.identity)
-  }
-  return value as A
+  return t.validate(value, type).fold(errors => {
+    throw new Error(failure(errors).join('\n'))
+  }, t.identity)
 }
 
 const parseError = (err: any) => {


### PR DESCRIPTION
Closes #27

## Test Plan

### tests performed
tested manually on alinity pro:
- before, when running in prod: `Uncaught TypeError: r.getFullYear is not a function` (a string that remained a string instead of being parsed as a Date)
- after: no errors in prod

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
