### PR TITLE
Exporting RouteConfig

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,7 @@ import axios, { AxiosError } from 'axios'
 import * as t from 'io-ts'
 import * as m from './model-ts'
 
-interface RouteConfig {
+export interface RouteConfig {
   apiEndpoint: string,
   timeout: number,
   unwrapApiResponse: (resp: any) => any

--- a/test/expected-route3.txt
+++ b/test/expected-route3.txt
@@ -3,7 +3,7 @@ import axios, { AxiosError } from 'axios'
 import * as t from 'io-ts'
 import * as m from './model-ts'
 
-interface RouteConfig {
+export interface RouteConfig {
   apiEndpoint: string,
   timeout: number,
   unwrapApiResponse: (resp: any) => any


### PR DESCRIPTION
The function `getRoutes(config: RouteConfig)` is exported, but the `RouteConfig` interface is not. This results in a failure of the TS build.