### PR TITLE
Add support for actual newtypes (closes #36)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ts-node": "3.3.0",
     "tslint": "4.4.2",
     "tslint-config-standard": "4.0.0",
-    "typescript": "^2.5.0",
+    "typescript": "^2.7.2",
     "typings-checker": "1.1.2"
   },
   "tags": [],

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -12,7 +12,8 @@ export type CaseClassMember = {
 export type CaseClass = {
   name: string
   members: Array<CaseClassMember>
-  desc?: string
+  desc?: string,
+  isValueClass: boolean
 }
 
 export type EnumClassValue = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,11 +111,6 @@ function getDeclarations(
   })
 }
 
-const getModelsPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
-import * as t from 'io-ts'
-
-`
-
 const newtypePrelude = `
 interface Newtype<URI, A> {
   _URI: URI
@@ -135,17 +130,22 @@ const iso = <S extends AnyNewtype>(): Iso<S, Carrier<S>> =>
 
 `
 
-export function getModels(models: Array<Model>, options: GetModelsOptions, prelude: string = getModelsPrelude): string {
+export function getModels(models: Array<Model>, options: GetModelsOptions, prelude: string = ''): string {
   const declarations = getDeclarations(models, options.isReadonly, options.optionalType || gen.undefinedType)
   const newtypeDeclarations: NewtypeRawDeclaration[] = declarations.filter((d): d is NewtypeRawDeclaration => d.kind === 'newtype')
   const typeDeclarations: gen.TypeDeclaration[] = declarations.filter((d): d is gen.TypeDeclaration => d.kind !== 'newtype')
   const sortedTypeDeclarations = gen.sort(sortBy(typeDeclarations, ({ name }) => name))
-  let out = ''
-  if (options.runtime) {
-    out += prelude
-  }
+  let out = [
+    '// DO NOT EDIT MANUALLY - metarpheus-generated',
+    "import * as t from 'io-ts'",
+    '',
+    ''
+  ].join('\n')
   if (newtypeDeclarations.length > 0) {
     out += newtypePrelude
+  }
+  if (options.runtime) {
+    out += prelude
   }
   out += newtypeDeclarations.map(d => d.declaration).join('\n')
   out += sortedTypeDeclarations

--- a/test/expected-model1.txt
+++ b/test/expected-model1.txt
@@ -1,6 +1,27 @@
 // DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'
 
+
+interface Newtype<URI, A> {
+  _URI: URI
+  _A: A
+}
+interface Iso<S, A> {
+  unwrap: (s: S) => A
+  wrap: (a: A) => S
+}
+const unsafeCoerce = <A, B>(a: A): B => a as any
+type Carrier<N extends Newtype<any, any>> = N['_A']
+type AnyNewtype = Newtype<any, any>
+const fromNewtype: <N extends AnyNewtype>(type: t.Type<t.mixed, Carrier<N>>) => t.Type<t.mixed, N> =
+  type => type as any
+const iso = <S extends AnyNewtype>(): Iso<S, Carrier<S>> =>
+  ({ wrap: unsafeCoerce, unwrap: unsafeCoerce })
+
+export interface HealthId extends NewType<'HealthId', string> {}
+export const HealthId = fromNewType<HealthId>(t.string)
+export const healthIdIso = iso<HealthId>()
+
 export type CampingLocation =
   | 'Seaside'
   | 'Mountains'
@@ -30,7 +51,7 @@ export const Camping = t.interface({
 
 export interface Health {
   /** Name of the service. */
-  id: string,
+  id: HealthId,
   /** Version of the service. */
   version: string,
   /** Current UTC date and time of the request, in ISO 8601 format. */
@@ -39,7 +60,7 @@ export interface Health {
 
 export const Health = t.interface({
   /** Name of the service. */
-  id: t.string,
+  id: HealthId,
   /** Version of the service. */
   version: t.string,
   /** Current UTC date and time of the request, in ISO 8601 format. */

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,28 +11,28 @@ describe('getModels', () => {
   it('should return the models (source1)', () => {
     const expected = fs.readFileSync(__dirname + '/expected-model1.txt', 'utf-8')
     const models: Array<Model> = require('./source1.json').models
-    const out = getModels(models, { isReadonly: false, runtime: true, newtypes: [] })
+    const out = getModels(models, { isReadonly: false, runtime: true })
     assert.strictEqual(trimRight(out), expected)
   })
 
   it('should return the models in the right (source2)', () => {
     const expected = fs.readFileSync(__dirname + '/expected-model2.txt', 'utf-8')
     const models: Array<Model> = require('./source2.json').models
-    const out = getModels(models, { isReadonly: true, runtime: true, newtypes: [] })
+    const out = getModels(models, { isReadonly: true, runtime: true })
     assert.strictEqual(trimRight(out), expected)
   })
 
   it('should return the models in the right (source3)', () => {
     const expected = fs.readFileSync(__dirname + '/expected-model3.txt', 'utf-8')
     const models: Array<Model> = require('./source3.json').models
-    const out = getModels(models, { isReadonly: false, runtime: true, newtypes: [] })
+    const out = getModels(models, { isReadonly: false, runtime: true })
     assert.strictEqual(trimRight(out), expected)
   })
 
   it('should handle any', () => {
     const expected = fs.readFileSync(__dirname + '/expected-model-any.txt', 'utf-8')
     const models: Array<Model> = require('./source-any.json').models
-    const out = getModels(models, { isReadonly: false, runtime: true, newtypes: [] })
+    const out = getModels(models, { isReadonly: false, runtime: true })
     assert.strictEqual(trimRight(out), expected)
   })
 })

--- a/test/source1.json
+++ b/test/source1.json
@@ -1,12 +1,24 @@
 {
   "models": [
     {
+      "name": "HealthId",
+      "members": [
+        {
+          "name": "value",
+          "tpe": {
+            "name": "String"
+          }
+        }
+      ],
+      "isValueClass": true
+    },
+    {
       "name": "Health",
       "members": [
         {
           "name": "id",
           "tpe": {
-            "name": "String"
+            "name": "HealthId"
           },
           "desc": "Name of the service."
         },


### PR DESCRIPTION
This is a first approximation of proper full-stack newtypes.

## Approach
In order to avoid bringing in a lot of dependencies (`newtype-ts`, `io-ts-types`, `monocle-ts`, etc), I've copy-pasted a stripped-down newtype encoding, along with a small `Iso` facility for wrapping/unwrapping.

## Limitations
Since newtypes are currently generated outside of `io-ts-gen` they're not topologically sorted. Instead, they're placed on top of the file, right after the prelude. In practical terms, this means that we only guarantee support for newtypes over primitive types (e.g. strings, numbers, etc), but not over custom types, due to the lack of sorting.

## Future work
This is an acceptable first step, but I would like to take this a bit further with the help of @gcanti. As discussed offline, we need a custom `io-ts-gen` `Node` where one can provide static and runtime types (including but not limited to newtypes).

## Breaking changes
- major: remove support for the `newtypes` configuration (which simply introduced a type alias)
- minor: now the `DO NOT EDIT MANUALLY` warning is always printed at the top of the file, even when providing a custom model prelude. This was necessary since we now have two preludes (model prelude and newtype prelude), but only one is overridable.