### PR TITLE
#55: Authenticated routes missing token parameter (closes #55)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -330,7 +330,7 @@ interface Param {
 }
 
 function getParamsToPrint(route: Route, params: Array<Param>): Reader<Ctx, Array<Param>> {
-  const p1 = route.authenticated ? params.filter(x => !(x.name === 'token' && x.type === 'string')) : params;
+  const p1 = route.authenticated ? [{ name: 'token', type: 'string' }, ...params] : params;
   return route.method === 'post' && route.body
     ? getType(route.body.tpe).map(bodyType =>
         // the name `data` for this param is hardcoded in `getRouteData`

--- a/test/expected-route3.txt
+++ b/test/expected-route3.txt
@@ -90,7 +90,7 @@ export default function getRoutes(config: RouteConfig) {
     },
 
     /** Updates the selected SpecialEquipments for the specified AvailableVehicle */
-    availableVehicleController_updateSpecialEquipments: function ({ availableVehicleId, specialEquipments }: { availableVehicleId: string, specialEquipments: Array<m.SelectedSpecialEquipment> }): Promise<string> {
+    availableVehicleController_updateSpecialEquipments: function ({ token, availableVehicleId, specialEquipments }: { token: string, availableVehicleId: string, specialEquipments: Array<m.SelectedSpecialEquipment> }): Promise<string> {
       return axios({
         method: 'post',
         url: `${config.apiEndpoint}/availableVehicles/updateSpecialEquipments`,
@@ -102,7 +102,8 @@ export default function getRoutes(config: RouteConfig) {
           specialEquipments
         },
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Authorization': `Token token="${token}"`
         },
         timeout: config.timeout
       }).then(res => valueOrThrow(t.string, config.unwrapApiResponse(res.data)), parseError) as any

--- a/test/source3.json
+++ b/test/source3.json
@@ -1699,7 +1699,7 @@
           "inBody": true
         }
       ],
-      "authenticated": false,
+      "authenticated": true,
       "returns": {
         "name": "UUID"
       },


### PR DESCRIPTION
Closes #55

The bug was introduced in #45, when refactoring a piece of mutable code that used `unshift`, which I completely misunderstood.

## Test Plan

### tests performed

unit tests (I've made sure there's at least one authenticated route)
