### PR TITLE
Handle non-string Map keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,12 +93,7 @@ export function getType(tpe: Tpe, owner: Tpe | null): Reader<Ctx, gen.TypeRefere
 
 function dictionaryCombinator(domain: gen.TypeReference, codomain: gen.TypeReference) {
   const defaultCombinator = gen.dictionaryCombinator(domain, codomain);
-  let staticRepr = '';
-  if (domain.kind === 'Identifier') {
-    staticRepr = `{ [key in ${gen.printStatic(domain)}]: ${gen.printStatic(codomain)} }`;
-  } else {
-    staticRepr = gen.printStatic(defaultCombinator);
-  }
+  const staticRepr = `{ [key in ${gen.printStatic(domain)}]: ${gen.printStatic(codomain)} }`;
   const runtimeRepr = gen.printRuntime(defaultCombinator);
   const dependencies = [...gen.getNodeDependencies(domain), ...gen.getNodeDependencies(codomain)];
   return gen.customCombinator(staticRepr, runtimeRepr, dependencies);

--- a/test/expected-model-any.txt
+++ b/test/expected-model-any.txt
@@ -4,7 +4,7 @@ import * as t from 'io-ts'
 export interface NotificationPayload {
   userLanguage?: string,
   notificationKind: NotificationKind,
-  params: { [key: string]: any },
+  params: { [key in string]: any },
   workcellSerialNumber: string,
   workcellType: InstrumentType
 }

--- a/test/expected-model3.txt
+++ b/test/expected-model3.txt
@@ -448,6 +448,35 @@ export const AvailableVehicleSearchResult = t.interface({
   availability: t.array(VehicleAvailability)
 }, 'AvailableVehicleSearchResult')
 
+export type DayOfWeek =
+  | 'Monday'
+  | 'Tuesday'
+  | 'Wednesday'
+  | 'Thursday'
+  | 'Friday'
+  | 'Saturday'
+  | 'Sunday'
+
+export const DayOfWeek = t.keyof({
+  Monday: true,
+  Tuesday: true,
+  Wednesday: true,
+  Thursday: true,
+  Friday: true,
+  Saturday: true,
+  Sunday: true
+}, 'DayOfWeek')
+
+export interface OpeningHours {
+  open: string,
+  close: string
+}
+
+export const OpeningHours = t.interface({
+  open: t.string,
+  close: t.string
+}, 'OpeningHours')
+
 export interface Location {
   recordType: string,
   actionCode: string,
@@ -467,48 +496,7 @@ export interface Location {
   telex: string,
   webUrl: string,
   email: string,
-  open1mon: string,
-  close1mon: string,
-  open2mon: string,
-  close2mon: string,
-  open3mon: string,
-  close3mon: string,
-  open1tue: string,
-  close1tue: string,
-  open2tue: string,
-  close2tue: string,
-  open3tue: string,
-  close3tue: string,
-  open1wed: string,
-  close1wed: string,
-  open2wed: string,
-  close2wed: string,
-  open3wed: string,
-  close3wed: string,
-  open1thu: string,
-  close1thu: string,
-  open2thu: string,
-  close2thu: string,
-  open3thu: string,
-  close3thu: string,
-  open1fri: string,
-  close1fri: string,
-  open2fri: string,
-  close2fri: string,
-  open3fri: string,
-  close3fri: string,
-  open1sat: string,
-  close1sat: string,
-  open2sat: string,
-  close2sat: string,
-  open3sat: string,
-  close3sat: string,
-  open1sun: string,
-  close1sun: string,
-  open2sun: string,
-  close2sun: string,
-  open3sun: string,
-  close3sun: string,
+  openingHours: { [key in DayOfWeek]: Array<OpeningHours> },
   latitude: string,
   longitude: string,
   description: string,
@@ -581,48 +569,7 @@ export const Location = t.interface({
   telex: t.string,
   webUrl: t.string,
   email: t.string,
-  open1mon: t.string,
-  close1mon: t.string,
-  open2mon: t.string,
-  close2mon: t.string,
-  open3mon: t.string,
-  close3mon: t.string,
-  open1tue: t.string,
-  close1tue: t.string,
-  open2tue: t.string,
-  close2tue: t.string,
-  open3tue: t.string,
-  close3tue: t.string,
-  open1wed: t.string,
-  close1wed: t.string,
-  open2wed: t.string,
-  close2wed: t.string,
-  open3wed: t.string,
-  close3wed: t.string,
-  open1thu: t.string,
-  close1thu: t.string,
-  open2thu: t.string,
-  close2thu: t.string,
-  open3thu: t.string,
-  close3thu: t.string,
-  open1fri: t.string,
-  close1fri: t.string,
-  open2fri: t.string,
-  close2fri: t.string,
-  open3fri: t.string,
-  close3fri: t.string,
-  open1sat: t.string,
-  close1sat: t.string,
-  open2sat: t.string,
-  close2sat: t.string,
-  open3sat: t.string,
-  close3sat: t.string,
-  open1sun: t.string,
-  close1sun: t.string,
-  open2sun: t.string,
-  close2sun: t.string,
-  open3sun: t.string,
-  close3sun: t.string,
+  openingHours: t.dictionary(DayOfWeek, t.array(OpeningHours)),
   latitude: t.string,
   longitude: t.string,
   description: t.string,

--- a/test/expected-model3.txt
+++ b/test/expected-model3.txt
@@ -425,12 +425,12 @@ export const AvailableVehicleSearchQuery = t.interface({
 
 export interface VehicleAvailability {
   vehicle: Vehicle,
-  availableRentalRatesByFare: { [key: string]: AvailableRentalRate }
+  availableRentalRatesByFare: { [key in UUID]: AvailableRentalRate }
 }
 
 export const VehicleAvailability = t.interface({
   vehicle: Vehicle,
-  availableRentalRatesByFare: t.dictionary(t.string, AvailableRentalRate)
+  availableRentalRatesByFare: t.dictionary(UUID, AvailableRentalRate)
 }, 'VehicleAvailability')
 
 export interface AvailableVehicleSearchResult {

--- a/test/source3.json
+++ b/test/source3.json
@@ -1,6 +1,49 @@
 {
   "models": [
     {
+      "name": "DayOfWeek",
+      "values": [
+        {
+          "name": "Monday"
+        },
+        {
+          "name": "Tuesday"
+        },
+        {
+          "name": "Wednesday"
+        },
+        {
+          "name": "Thursday"
+        },
+        {
+          "name": "Friday"
+        },
+        {
+          "name": "Saturday"
+        },
+        {
+          "name": "Sunday"
+        }
+      ]
+    },
+    {
+      "name": "OpeningHours",
+      "members": [
+        {
+          "name": "open",
+          "tpe": {
+            "name": "String"
+          }
+        },
+        {
+          "name": "close",
+          "tpe": {
+            "name": "String"
+          }
+        }
+      ]
+    },
+    {
       "name": "ReservationProfile",
       "values": [
         {
@@ -382,255 +425,22 @@
           }
         },
         {
-          "name": "open1mon",
+          "name": "openingHours",
           "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close1mon",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open2mon",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close2mon",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open3mon",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close3mon",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open1tue",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close1tue",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open2tue",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close2tue",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open3tue",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close3tue",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open1wed",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close1wed",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open2wed",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close2wed",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open3wed",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close3wed",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open1thu",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close1thu",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open2thu",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close2thu",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open3thu",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close3thu",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open1fri",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close1fri",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open2fri",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close2fri",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open3fri",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close3fri",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open1sat",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close1sat",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open2sat",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close2sat",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open3sat",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close3sat",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open1sun",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close1sun",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open2sun",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close2sun",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "open3sun",
-          "tpe": {
-            "name": "String"
-          }
-        },
-        {
-          "name": "close3sun",
-          "tpe": {
-            "name": "String"
+            "name": "Map",
+            "args": [
+              {
+                "name" : "DayOfWeek"
+              },
+              {
+                "name" : "List",
+                "args" : [
+                  {
+                    "name" : "OpeningHours"
+                  }
+                ]
+              }
+            ]
           }
         },
         {


### PR DESCRIPTION
Example:

```scala
@enum trait DayOfWeek {
  case Monday
  case Tuesday
  // ...
}
case class OpeningHours(open: String, close: String)
case class Location(openingHours: Map[DayOfWeek, Array[OpeningHours]])
```

Currently we encode `Location` as:

```typescript
interface Location {
  openingHours: { [k: string]: Array<OpeningHours> }
}

const Location = t.interface({
  openingHours: t.dictionary(t.string, OpeningHours)
}
```

This PR changes the representation of the dictionary so that it preserves the type:

```typescript
interface Location {
  openingHours: { [k in DayOfWeek]: Array<OpeningHours> }
}

const Location = t.interface({
  openingHours: t.dictionary(DayOfWeek, OpeningHours)
}
```

I had to define a custom type combinator due to an apparent bug in io-ts-codegen.