### PR TITLE
#91: generate TaskEither APIs (instead of Promise) (closes #91)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "homepage": "https://github.com/gcanti/metarpheus-io-ts",
   "dependencies": {
     "commander": "^2.9.0",
-    "fp-ts": "^1.12.0",
-    "io-ts-codegen": "0.3.0",
+    "fp-ts": "^1.16.1",
+    "io-ts-codegen": "0.3.3",
     "lodash": "^4.17.4"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "@types/lodash": "^4.14.76",
     "@types/node": "7.0.4",
     "axios": "^0.17.1",
-    "io-ts": "^1.7.1",
+    "io-ts": "^1.8.5",
     "jest": "^23.6.0",
     "prettier": "^1.11.1",
     "smooth-release": "^8.0.4",
@@ -51,7 +51,7 @@
     "ts-node": "^5.0.1",
     "tslint": "4.4.2",
     "tslint-config-standard": "4.0.0",
-    "typescript": "^3.2.0"
+    "typescript": "^3.4.3"
   },
   "tags": [],
   "keywords": [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -393,8 +393,8 @@ function getRoute(_route: Route): Reader<Ctx, string> {
           return [
             `${docs}    ${name}: function (${routeArguments}): TaskEither<AxiosError, ${gen.printStatic(returns)}> {`,
             `      return tryCatch(() => axios(${axiosConfig}), identity).map(res =>
-              ${gen.printRuntime(returns)}.decode(res.data).getOrElseL(err => {
-                throw err;
+              ${gen.printRuntime(returns)}.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\n'));
               })
             ) as any`,
             '    }'
@@ -410,6 +410,7 @@ import axios, { AxiosError } from 'axios'
 import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
+import { failure } from 'io-ts/lib/PathReporter'
 import * as m from './model-ts'
 
 export interface RouteConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,7 +407,7 @@ function getRoute(_route: Route): Reader<Ctx, string> {
 
 const getRoutesPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
 import axios, { AxiosError } from 'axios'
-import { tryCatch, TaskEither, fromEither } from 'fp-ts/lib/TaskEither'
+import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import * as m from './model-ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -391,12 +391,12 @@ function getRoute(_route: Route): Reader<Ctx, string> {
         getRouteArguments(route).map(routeArguments => {
           const docs = route.desc ? `    /** ${route.desc} */\n` : '';
           return [
-            `${docs}    ${name}: function (${routeArguments}): TaskEither<AxiosError | t.Errors, ${gen.printStatic(
-              returns
-            )}> {`,
-            `      return tryCatch(() => axios(${axiosConfig}), identity).chain(res => fromEither(${gen.printRuntime(
-              returns
-            )}.decode(res.data))) as any`,
+            `${docs}    ${name}: function (${routeArguments}): TaskEither<AxiosError, ${gen.printStatic(returns)}> {`,
+            `      return tryCatch(() => axios(${axiosConfig}), identity).map(res =>
+              ${gen.printRuntime(returns)}.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any`,
             '    }'
           ].join('\n');
         })

--- a/src/index.ts
+++ b/src/index.ts
@@ -391,10 +391,12 @@ function getRoute(_route: Route): Reader<Ctx, string> {
         getRouteArguments(route).map(routeArguments => {
           const docs = route.desc ? `    /** ${route.desc} */\n` : '';
           return [
-            `${docs}    ${name}: function (${routeArguments}): Promise<${gen.printStatic(returns)}> {`,
-            `      return axios(${axiosConfig}).then(res => valueOrThrow(${gen.printRuntime(
+            `${docs}    ${name}: function (${routeArguments}): TaskEither<AxiosError | t.Errors, ${gen.printStatic(
               returns
-            )}, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any`,
+            )}> {`,
+            `      return tryCatch(() => axios(${axiosConfig}), identity).chain(res => fromEither(${gen.printRuntime(
+              returns
+            )}.decode(res.data))) as any`,
             '    }'
           ].join('\n');
         })
@@ -405,34 +407,15 @@ function getRoute(_route: Route): Reader<Ctx, string> {
 
 const getRoutesPrelude = `// DO NOT EDIT MANUALLY - metarpheus-generated
 import axios, { AxiosError } from 'axios'
+import { tryCatch, TaskEither, fromEither } from 'fp-ts/lib/TaskEither'
+import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import * as m from './model-ts'
 
 export interface RouteConfig {
   apiEndpoint: string,
-  timeout: number,
-  unwrapApiResponse: (resp: any) => any
+  timeout: number
 }
-
-import { PathReporter } from 'io-ts/lib/PathReporter'
-function valueOrThrow<T extends t.Type<any, any>>(iotsType: T, value: T['_I']): t.TypeOf<T> {
-  const validatedValue = iotsType.decode(value);
-
-  if (validatedValue.isLeft()) {
-    throw new Error(PathReporter.report(validatedValue).join('\\n'));
-  }
-
-  return validatedValue.value;
-}
-
-const parseError = (err: AxiosError) => {
-  try {
-    const { errors = [] } = err.response!.data;
-    return Promise.reject({ status: err.response!.status, errors });
-  } catch (e) {
-    return Promise.reject({ status: err && err.response && err.response.status || 0, errors: [] });
-  }
-};
 `;
 
 export function getRoutes(

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1843,6 +1843,7 @@ import axios, { AxiosError } from 'axios'
 import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
+import { failure } from 'io-ts/lib/PathReporter'
 import * as m from './model-ts'
 
 export interface RouteConfig {
@@ -1868,8 +1869,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.UUID.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.UUID.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -1892,8 +1893,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.AvailableVehicleSearchQuery.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.AvailableVehicleSearchQuery.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -1916,8 +1917,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.AvailableVehicleSearchResult.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.AvailableVehicleSearchResult.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -1940,8 +1941,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.UUID.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.UUID.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -1964,8 +1965,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.AvailableVehicle.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.AvailableVehicle.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -1988,8 +1989,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.LocationSearchResult.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.LocationSearchResult.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2013,8 +2014,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              t.array(m.AvailableSpecialEquipment).decode(res.data).getOrElseL(err => {
-                throw err;
+              t.array(m.AvailableSpecialEquipment).decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2033,8 +2034,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.API_UserAuthCredentials.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.API_UserAuthCredentials.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     }
@@ -2049,6 +2050,7 @@ import axios, { AxiosError } from 'axios'
 import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
+import { failure } from 'io-ts/lib/PathReporter'
 import * as m from './model-ts'
 
 export interface RouteConfig {
@@ -2075,8 +2077,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              t.array(m.Entity(m.Material)).decode(res.data).getOrElseL(err => {
-                throw err;
+              t.array(m.Entity(m.Material)).decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2096,8 +2098,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.CalculationOutput.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.CalculationOutput.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2119,8 +2121,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.Entity(m.User).decode(res.data).getOrElseL(err => {
-                throw err;
+              m.Entity(m.User).decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2142,8 +2144,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              t.array(m.Entity(m.User)).decode(res.data).getOrElseL(err => {
-                throw err;
+              t.array(m.Entity(m.User)).decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2165,8 +2167,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.Entity(m.User).decode(res.data).getOrElseL(err => {
-                throw err;
+              m.Entity(m.User).decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2191,8 +2193,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.Id<m.User>().decode(res.data).getOrElseL(err => {
-                throw err;
+              m.Id<m.User>().decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2212,8 +2214,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.VoidFromUnit.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.VoidFromUnit.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     },
@@ -2233,8 +2235,8 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).map(res =>
-              m.VoidFromUnit.decode(res.data).getOrElseL(err => {
-                throw err;
+              m.VoidFromUnit.decode(res.data).getOrElseL(errors => {
+                throw new Error(failure(errors).join('\\\\n'));
               })
             ) as any
     }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1840,40 +1840,21 @@ export const User = t.intersection([
 exports[`getRoutes should return the routes in the right (source3) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import axios, { AxiosError } from 'axios'
+import { tryCatch, TaskEither, fromEither } from 'fp-ts/lib/TaskEither'
+import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import * as m from './model-ts'
 
 export interface RouteConfig {
   apiEndpoint: string,
-  timeout: number,
-  unwrapApiResponse: (resp: any) => any
+  timeout: number
 }
-
-import { PathReporter } from 'io-ts/lib/PathReporter'
-function valueOrThrow<T extends t.Type<any, any>>(iotsType: T, value: T['_I']): t.TypeOf<T> {
-  const validatedValue = iotsType.decode(value);
-
-  if (validatedValue.isLeft()) {
-    throw new Error(PathReporter.report(validatedValue).join('\\\\n'));
-  }
-
-  return validatedValue.value;
-}
-
-const parseError = (err: AxiosError) => {
-  try {
-    const { errors = [] } = err.response!.data;
-    return Promise.reject({ status: err.response!.status, errors });
-  } catch (e) {
-    return Promise.reject({ status: err && err.response && err.response.status || 0, errors: [] });
-  }
-};
 
 export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
   return {
     /** Create a new search query for available vehicles */
-    availableVehicleController_createQuery: function ({ query }: { query: m.AvailableVehicleSearchQuery }): Promise<m.UUID> {
-      return axios({
+    availableVehicleController_createQuery: function ({ query }: { query: m.AvailableVehicleSearchQuery }): TaskEither<AxiosError | t.Errors, m.UUID> {
+      return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/createQuery\`,
         params: {
@@ -1886,12 +1867,12 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.UUID, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.UUID.decode(res.data))) as any
     },
 
     /** Returns an existing query for available vehicles */
-    availableVehicleController_readQuery: function ({ id }: { id: m.UUID }): Promise<m.AvailableVehicleSearchQuery> {
-      return axios({
+    availableVehicleController_readQuery: function ({ id }: { id: m.UUID }): TaskEither<AxiosError | t.Errors, m.AvailableVehicleSearchQuery> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/readQuery\`,
         params: {
@@ -1906,12 +1887,12 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.AvailableVehicleSearchQuery, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.AvailableVehicleSearchQuery.decode(res.data))) as any
     },
 
     /** Returns the resulting available vehicles for the created query */
-    availableVehicleController_readResult: function ({ id }: { id: m.UUID }): Promise<m.AvailableVehicleSearchResult> {
-      return axios({
+    availableVehicleController_readResult: function ({ id }: { id: m.UUID }): TaskEither<AxiosError | t.Errors, m.AvailableVehicleSearchResult> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/readResult\`,
         params: {
@@ -1926,12 +1907,12 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.AvailableVehicleSearchResult, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.AvailableVehicleSearchResult.decode(res.data))) as any
     },
 
     /** Updates the selected SpecialEquipments for the specified AvailableVehicle */
-    availableVehicleController_updateSpecialEquipments: function ({ token, availableVehicleId, specialEquipments }: { token: string, availableVehicleId: m.UUID, specialEquipments: Array<m.SelectedSpecialEquipment> }): Promise<m.UUID> {
-      return axios({
+    availableVehicleController_updateSpecialEquipments: function ({ token, availableVehicleId, specialEquipments }: { token: string, availableVehicleId: m.UUID, specialEquipments: Array<m.SelectedSpecialEquipment> }): TaskEither<AxiosError | t.Errors, m.UUID> {
+      return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/updateSpecialEquipments\`,
         params: {
@@ -1946,12 +1927,12 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Authorization': \`Token token=\\"\${token}\\"\`
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.UUID, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.UUID.decode(res.data))) as any
     },
 
     /** Returns the specified available vehicle */
-    availableVehicleController_read: function ({ id }: { id: m.UUID }): Promise<m.AvailableVehicle> {
-      return axios({
+    availableVehicleController_read: function ({ id }: { id: m.UUID }): TaskEither<AxiosError | t.Errors, m.AvailableVehicle> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/read\`,
         params: {
@@ -1966,12 +1947,12 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.AvailableVehicle, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.AvailableVehicle.decode(res.data))) as any
     },
 
     /** Search locations */
-    locationsController_search: function ({ query }: { query: string }): Promise<m.LocationSearchResult> {
-      return axios({
+    locationsController_search: function ({ query }: { query: string }): TaskEither<AxiosError | t.Errors, m.LocationSearchResult> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/locations/search\`,
         params: {
@@ -1986,12 +1967,12 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.LocationSearchResult, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.LocationSearchResult.decode(res.data))) as any
     },
 
     /** Get available SpecialEquipment for a given pickUp Location and rental duration */
-    locationsController_searchSpecialEquipments: function ({ location, duration, param1, param2 }: { location: string, duration: number, param1: number, param2: string }): Promise<Array<m.AvailableSpecialEquipment>> {
-      return axios({
+    locationsController_searchSpecialEquipments: function ({ location, duration, param1, param2 }: { location: string, duration: number, param1: number, param2: string }): TaskEither<AxiosError | t.Errors, Array<m.AvailableSpecialEquipment>> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/locations/searchSpecialEquipments/\${param1}/foo/\${param2}\`,
         params: {
@@ -2007,12 +1988,12 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(t.array(m.AvailableSpecialEquipment), _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(t.array(m.AvailableSpecialEquipment).decode(res.data))) as any
     },
 
     /** log a user in */
-    userController_login: function ({ data }: { data: m.API_UserLoginCredentials }): Promise<m.API_UserAuthCredentials> {
-      return axios({
+    userController_login: function ({ data }: { data: m.API_UserLoginCredentials }): TaskEither<AxiosError | t.Errors, m.API_UserAuthCredentials> {
+      return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/users/login\`,
         params: {
@@ -2023,7 +2004,7 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.API_UserAuthCredentials, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.API_UserAuthCredentials.decode(res.data))) as any
     }
   }
 }
@@ -2033,39 +2014,20 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
 exports[`getRoutes should return the routes in the right (source4) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import axios, { AxiosError } from 'axios'
+import { tryCatch, TaskEither, fromEither } from 'fp-ts/lib/TaskEither'
+import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import * as m from './model-ts'
 
 export interface RouteConfig {
   apiEndpoint: string,
-  timeout: number,
-  unwrapApiResponse: (resp: any) => any
+  timeout: number
 }
-
-import { PathReporter } from 'io-ts/lib/PathReporter'
-function valueOrThrow<T extends t.Type<any, any>>(iotsType: T, value: T['_I']): t.TypeOf<T> {
-  const validatedValue = iotsType.decode(value);
-
-  if (validatedValue.isLeft()) {
-    throw new Error(PathReporter.report(validatedValue).join('\\\\n'));
-  }
-
-  return validatedValue.value;
-}
-
-const parseError = (err: AxiosError) => {
-  try {
-    const { errors = [] } = err.response!.data;
-    return Promise.reject({ status: err.response!.status, errors });
-  } catch (e) {
-    return Promise.reject({ status: err && err.response && err.response.status || 0, errors: [] });
-  }
-};
 
 export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
   return {
-    materialController_readAll: function ({  }: {  }): Promise<Array<m.Entity<m.Material>>> {
-      return axios({
+    materialController_readAll: function ({  }: {  }): TaskEither<AxiosError | t.Errors, Array<m.Entity<m.Material>>> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/material/readAll\`,
         params: {
@@ -2080,11 +2042,11 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(t.array(m.Entity(m.Material)), _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(t.array(m.Entity(m.Material)).decode(res.data))) as any
     },
 
-    calculationController_run: function ({ calculation }: { calculation: m.CalculationInput }): Promise<m.CalculationOutput> {
-      return axios({
+    calculationController_run: function ({ calculation }: { calculation: m.CalculationInput }): TaskEither<AxiosError | t.Errors, m.CalculationOutput> {
+      return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/calculation/run\`,
         params: {
@@ -2097,11 +2059,11 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.CalculationOutput, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.CalculationOutput.decode(res.data))) as any
     },
 
-    meController_read: function ({  }: {  }): Promise<m.Entity<m.User>> {
-      return axios({
+    meController_read: function ({  }: {  }): TaskEither<AxiosError | t.Errors, m.Entity<m.User>> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/me/read\`,
         params: {
@@ -2116,11 +2078,11 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.Entity(m.User), _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.Entity(m.User).decode(res.data))) as any
     },
 
-    userController_readAll: function ({  }: {  }): Promise<Array<m.Entity<m.User>>> {
-      return axios({
+    userController_readAll: function ({  }: {  }): TaskEither<AxiosError | t.Errors, Array<m.Entity<m.User>>> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/readAll\`,
         params: {
@@ -2135,11 +2097,11 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(t.array(m.Entity(m.User)), _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(t.array(m.Entity(m.User)).decode(res.data))) as any
     },
 
-    userController_read: function ({ id }: { id: m.Id<m.User> }): Promise<m.Entity<m.User>> {
-      return axios({
+    userController_read: function ({ id }: { id: m.Id<m.User> }): TaskEither<AxiosError | t.Errors, m.Entity<m.User>> {
+      return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/read\`,
         params: {
@@ -2154,13 +2116,13 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.Entity(m.User), _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.Entity(m.User).decode(res.data))) as any
     },
 
     userController_create: function ({ user }: { user:
   | m.User
-  | undefined }): Promise<m.Id<m.User>> {
-      return axios({
+  | undefined }): TaskEither<AxiosError | t.Errors, m.Id<m.User>> {
+      return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/create\`,
         params: {
@@ -2176,11 +2138,11 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.Id<m.User>(), _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.Id<m.User>().decode(res.data))) as any
     },
 
-    userController_update: function ({ user }: { user: m.Entity<m.User> }): Promise<void> {
-      return axios({
+    userController_update: function ({ user }: { user: m.Entity<m.User> }): TaskEither<AxiosError | t.Errors, void> {
+      return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/update\`,
         params: {
@@ -2193,11 +2155,11 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.VoidFromUnit, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.VoidFromUnit.decode(res.data))) as any
     },
 
-    userController_delete: function ({ id }: { id: m.Id<m.User> }): Promise<void> {
-      return axios({
+    userController_delete: function ({ id }: { id: m.Id<m.User> }): TaskEither<AxiosError | t.Errors, void> {
+      return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/delete\`,
         params: {
@@ -2210,7 +2172,7 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }).then(res => valueOrThrow(m.VoidFromUnit, _metarpheusRouteConfig.unwrapApiResponse(res.data)), parseError) as any
+      }), identity).chain(res => fromEither(m.VoidFromUnit.decode(res.data))) as any
     }
   }
 }

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -62,7 +62,7 @@ export const NotificationPayload = t.intersection([
   t.partial({
     userLanguage: t.string
   })
-])
+], 'NotificationPayload')
 "
 `;
 
@@ -180,7 +180,7 @@ export const ICQAlert = t.intersection([
   t.partial({
     AIMSubCode: t.Integer
   })
-])
+], 'ICQAlert')
 
 export interface ICQAssayReference {
   _number: number,
@@ -305,7 +305,7 @@ export const ICQCalibration = t.intersection([
     expirationDateTime: Date,
     user: t.string
   })
-])
+], 'ICQCalibration')
 
 export type ICQConnectionStatus =
   | 'Connected'
@@ -446,7 +446,7 @@ export const ICQOnBoardSolution = t.intersection([
     RSMPosition: t.Integer,
     remainingHoursOfOnBoardStability: t.Integer
   })
-])
+], 'ICQOnBoardSolution')
 
 export type ICQOverallStatus =
   | 'Ok'
@@ -602,7 +602,7 @@ export const ICQQCMaterial = t.intersection([
     RSMPosition: t.Integer,
     remainingMinutesOfInUseStability: t.Integer
   })
-])
+], 'ICQQCMaterial')
 
 export type ICQRSMStatus =
   | 'Offline'
@@ -687,7 +687,7 @@ export type Tag = Readonly<{
 export const Tag = t.readonly(t.type({
   id: UUID,
   label: t.string
-}, 'Tag'))
+}, 'Tag'), 'Tag')
 
 export type AgencySearchResult = Readonly<{
   agencies: ReadonlyArray<Tag>,
@@ -697,7 +697,7 @@ export type AgencySearchResult = Readonly<{
 export const AgencySearchResult = t.readonly(t.type({
   agencies: t.readonlyArray(Tag),
   networks: t.readonlyArray(Tag)
-}, 'AgencySearchResult'))
+}, 'AgencySearchResult'), 'AgencySearchResult')
 
 export type CancellationPolicy =
   | 'Free'
@@ -748,7 +748,7 @@ export const FareRule = t.readonly(t.intersection([
     reservationValidFrom: LocalDate,
     reservationValidUntil: LocalDate
   })
-]))
+], 'FareRule'), 'FareRule')
 
 export type Fare = Readonly<{
   id: UUID,
@@ -782,7 +782,7 @@ export const Fare = t.readonly(t.intersection([
     tourOperatorCode: t.string,
     additionalInclusions: t.string
   })
-]))
+], 'Fare'), 'Fare')
 
 export type ReservationProfile =
   | 'Leisure'
@@ -811,7 +811,7 @@ export const FareSummary = t.readonly(t.type({
   vendor: Vendor,
   paymentMode: PaymentMode,
   disabled: t.boolean
-}, 'FareSummary'))
+}, 'FareSummary'), 'FareSummary')
 
 export type FareSummarySorting =
   | 'Name'
@@ -836,7 +836,7 @@ export const NationSearchResult = t.readonly(t.type({
   regions: t.readonlyArray(Tag),
   countries: t.readonlyArray(Tag),
   states: t.readonlyArray(Tag)
-}, 'NationSearchResult'))
+}, 'NationSearchResult'), 'NationSearchResult')
 
 export type NewFare = Readonly<{
   name: string,
@@ -868,7 +868,7 @@ export const NewFare = t.readonly(t.intersection([
     additionalInclusions: t.string,
     tourOperatorCode: t.string
   })
-]))
+], 'NewFare'), 'NewFare')
 
 export type SortOrder =
   | 'Ascending'
@@ -944,7 +944,7 @@ export const AvailableFare = t.intersection([
     explicitExclusions: t.string,
     description: t.string
   })
-])
+], 'AvailableFare')
 
 export interface RentalRateTotal {
   base: Money,
@@ -983,7 +983,7 @@ export const RentalRateDistance = t.intersection([
     amount: t.Integer,
     additional: Money
   })
-])
+], 'RentalRateDistance')
 
 export type SpecialEquipment =
   | 'InfantChildSeat'
@@ -1036,7 +1036,7 @@ export const RentalRate = t.intersection([
   t.partial({
     dropOff: Money
   })
-])
+], 'RentalRate')
 
 export interface AvailableRentalRate {
   availableVehicleId: UUID,
@@ -1233,7 +1233,7 @@ export const Vehicle = t.intersection([
     doors: t.Integer,
     segment: t.string
   })
-])
+], 'Vehicle')
 
 export interface AvailableVehicle {
   id: UUID,
@@ -1308,7 +1308,7 @@ export const AvailableVehicleSearchResult = t.intersection([
   t.partial({
     taxPercent: t.number
   })
-])
+], 'AvailableVehicleSearchResult')
 
 export type DayOfWeek =
   | 'Monday'
@@ -1497,7 +1497,7 @@ export const LocationSearchResult = t.partial({
   stations: t.array(Location),
   cities: t.array(Location),
   hotels: t.array(Location)
-})
+}, 'LocationSearchResult')
 
 export interface SelectedSpecialEquipment {
   id: SpecialEquipment,
@@ -1833,7 +1833,7 @@ export const User = t.intersection([
   t.partial({
     fullName: t.string
   })
-])
+], 'User')
 "
 `;
 

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1840,7 +1840,7 @@ export const User = t.intersection([
 exports[`getRoutes should return the routes in the right (source3) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import axios, { AxiosError } from 'axios'
-import { tryCatch, TaskEither, fromEither } from 'fp-ts/lib/TaskEither'
+import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import * as m from './model-ts'
@@ -2046,7 +2046,7 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
 exports[`getRoutes should return the routes in the right (source4) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import axios, { AxiosError } from 'axios'
-import { tryCatch, TaskEither, fromEither } from 'fp-ts/lib/TaskEither'
+import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import * as m from './model-ts'

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1853,7 +1853,7 @@ export interface RouteConfig {
 export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
   return {
     /** Create a new search query for available vehicles */
-    availableVehicleController_createQuery: function ({ query }: { query: m.AvailableVehicleSearchQuery }): TaskEither<AxiosError | t.Errors, m.UUID> {
+    availableVehicleController_createQuery: function ({ query }: { query: m.AvailableVehicleSearchQuery }): TaskEither<AxiosError, m.UUID> {
       return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/createQuery\`,
@@ -1867,11 +1867,15 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.UUID.decode(res.data))) as any
+      }), identity).map(res =>
+              m.UUID.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
     /** Returns an existing query for available vehicles */
-    availableVehicleController_readQuery: function ({ id }: { id: m.UUID }): TaskEither<AxiosError | t.Errors, m.AvailableVehicleSearchQuery> {
+    availableVehicleController_readQuery: function ({ id }: { id: m.UUID }): TaskEither<AxiosError, m.AvailableVehicleSearchQuery> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/readQuery\`,
@@ -1887,11 +1891,15 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.AvailableVehicleSearchQuery.decode(res.data))) as any
+      }), identity).map(res =>
+              m.AvailableVehicleSearchQuery.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
     /** Returns the resulting available vehicles for the created query */
-    availableVehicleController_readResult: function ({ id }: { id: m.UUID }): TaskEither<AxiosError | t.Errors, m.AvailableVehicleSearchResult> {
+    availableVehicleController_readResult: function ({ id }: { id: m.UUID }): TaskEither<AxiosError, m.AvailableVehicleSearchResult> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/readResult\`,
@@ -1907,11 +1915,15 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.AvailableVehicleSearchResult.decode(res.data))) as any
+      }), identity).map(res =>
+              m.AvailableVehicleSearchResult.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
     /** Updates the selected SpecialEquipments for the specified AvailableVehicle */
-    availableVehicleController_updateSpecialEquipments: function ({ token, availableVehicleId, specialEquipments }: { token: string, availableVehicleId: m.UUID, specialEquipments: Array<m.SelectedSpecialEquipment> }): TaskEither<AxiosError | t.Errors, m.UUID> {
+    availableVehicleController_updateSpecialEquipments: function ({ token, availableVehicleId, specialEquipments }: { token: string, availableVehicleId: m.UUID, specialEquipments: Array<m.SelectedSpecialEquipment> }): TaskEither<AxiosError, m.UUID> {
       return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/updateSpecialEquipments\`,
@@ -1927,11 +1939,15 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Authorization': \`Token token=\\"\${token}\\"\`
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.UUID.decode(res.data))) as any
+      }), identity).map(res =>
+              m.UUID.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
     /** Returns the specified available vehicle */
-    availableVehicleController_read: function ({ id }: { id: m.UUID }): TaskEither<AxiosError | t.Errors, m.AvailableVehicle> {
+    availableVehicleController_read: function ({ id }: { id: m.UUID }): TaskEither<AxiosError, m.AvailableVehicle> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/availableVehicles/read\`,
@@ -1947,11 +1963,15 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.AvailableVehicle.decode(res.data))) as any
+      }), identity).map(res =>
+              m.AvailableVehicle.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
     /** Search locations */
-    locationsController_search: function ({ query }: { query: string }): TaskEither<AxiosError | t.Errors, m.LocationSearchResult> {
+    locationsController_search: function ({ query }: { query: string }): TaskEither<AxiosError, m.LocationSearchResult> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/locations/search\`,
@@ -1967,11 +1987,15 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.LocationSearchResult.decode(res.data))) as any
+      }), identity).map(res =>
+              m.LocationSearchResult.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
     /** Get available SpecialEquipment for a given pickUp Location and rental duration */
-    locationsController_searchSpecialEquipments: function ({ location, duration, param1, param2 }: { location: string, duration: number, param1: number, param2: string }): TaskEither<AxiosError | t.Errors, Array<m.AvailableSpecialEquipment>> {
+    locationsController_searchSpecialEquipments: function ({ location, duration, param1, param2 }: { location: string, duration: number, param1: number, param2: string }): TaskEither<AxiosError, Array<m.AvailableSpecialEquipment>> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/locations/searchSpecialEquipments/\${param1}/foo/\${param2}\`,
@@ -1988,11 +2012,15 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(t.array(m.AvailableSpecialEquipment).decode(res.data))) as any
+      }), identity).map(res =>
+              t.array(m.AvailableSpecialEquipment).decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
     /** log a user in */
-    userController_login: function ({ data }: { data: m.API_UserLoginCredentials }): TaskEither<AxiosError | t.Errors, m.API_UserAuthCredentials> {
+    userController_login: function ({ data }: { data: m.API_UserLoginCredentials }): TaskEither<AxiosError, m.API_UserAuthCredentials> {
       return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/users/login\`,
@@ -2004,7 +2032,11 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.API_UserAuthCredentials.decode(res.data))) as any
+      }), identity).map(res =>
+              m.API_UserAuthCredentials.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     }
   }
 }
@@ -2026,7 +2058,7 @@ export interface RouteConfig {
 
 export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
   return {
-    materialController_readAll: function ({  }: {  }): TaskEither<AxiosError | t.Errors, Array<m.Entity<m.Material>>> {
+    materialController_readAll: function ({  }: {  }): TaskEither<AxiosError, Array<m.Entity<m.Material>>> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/material/readAll\`,
@@ -2042,10 +2074,14 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(t.array(m.Entity(m.Material)).decode(res.data))) as any
+      }), identity).map(res =>
+              t.array(m.Entity(m.Material)).decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
-    calculationController_run: function ({ calculation }: { calculation: m.CalculationInput }): TaskEither<AxiosError | t.Errors, m.CalculationOutput> {
+    calculationController_run: function ({ calculation }: { calculation: m.CalculationInput }): TaskEither<AxiosError, m.CalculationOutput> {
       return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/calculation/run\`,
@@ -2059,10 +2095,14 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.CalculationOutput.decode(res.data))) as any
+      }), identity).map(res =>
+              m.CalculationOutput.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
-    meController_read: function ({  }: {  }): TaskEither<AxiosError | t.Errors, m.Entity<m.User>> {
+    meController_read: function ({  }: {  }): TaskEither<AxiosError, m.Entity<m.User>> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/me/read\`,
@@ -2078,10 +2118,14 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.Entity(m.User).decode(res.data))) as any
+      }), identity).map(res =>
+              m.Entity(m.User).decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
-    userController_readAll: function ({  }: {  }): TaskEither<AxiosError | t.Errors, Array<m.Entity<m.User>>> {
+    userController_readAll: function ({  }: {  }): TaskEither<AxiosError, Array<m.Entity<m.User>>> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/readAll\`,
@@ -2097,10 +2141,14 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(t.array(m.Entity(m.User)).decode(res.data))) as any
+      }), identity).map(res =>
+              t.array(m.Entity(m.User)).decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
-    userController_read: function ({ id }: { id: m.Id<m.User> }): TaskEither<AxiosError | t.Errors, m.Entity<m.User>> {
+    userController_read: function ({ id }: { id: m.Id<m.User> }): TaskEither<AxiosError, m.Entity<m.User>> {
       return tryCatch(() => axios({
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/read\`,
@@ -2116,12 +2164,16 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Cache-Control': 'no-cache, no-store'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.Entity(m.User).decode(res.data))) as any
+      }), identity).map(res =>
+              m.Entity(m.User).decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
     userController_create: function ({ user }: { user:
   | m.User
-  | undefined }): TaskEither<AxiosError | t.Errors, m.Id<m.User>> {
+  | undefined }): TaskEither<AxiosError, m.Id<m.User>> {
       return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/create\`,
@@ -2138,10 +2190,14 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.Id<m.User>().decode(res.data))) as any
+      }), identity).map(res =>
+              m.Id<m.User>().decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
-    userController_update: function ({ user }: { user: m.Entity<m.User> }): TaskEither<AxiosError | t.Errors, void> {
+    userController_update: function ({ user }: { user: m.Entity<m.User> }): TaskEither<AxiosError, void> {
       return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/update\`,
@@ -2155,10 +2211,14 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.VoidFromUnit.decode(res.data))) as any
+      }), identity).map(res =>
+              m.VoidFromUnit.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     },
 
-    userController_delete: function ({ id }: { id: m.Id<m.User> }): TaskEither<AxiosError | t.Errors, void> {
+    userController_delete: function ({ id }: { id: m.Id<m.User> }): TaskEither<AxiosError, void> {
       return tryCatch(() => axios({
         method: 'post',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/delete\`,
@@ -2172,7 +2232,11 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
           'Content-Type': 'application/json'
         },
         timeout: _metarpheusRouteConfig.timeout
-      }), identity).chain(res => fromEither(m.VoidFromUnit.decode(res.data))) as any
+      }), identity).map(res =>
+              m.VoidFromUnit.decode(res.data).getOrElseL(err => {
+                throw err;
+              })
+            ) as any
     }
   }
 }


### PR DESCRIPTION
Closes [#2522358](https://buildo.kaiten.io/space/[object Object]/card/2522358)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #91

## Test Plan

tested this at runtime on a project locally: https://github.com/buildo/getjenny/compare/test-metarpheus-taskeither

### tests performed

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
