### PR TITLE
#94: Generated type should be partial in case of a Record with an enum as key type (closes #94)

### DIFF
--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1358,7 +1358,15 @@ export interface Location {
   telex: string,
   webUrl: string,
   email: string,
-  openingHours: Record<DayOfWeek, Array<OpeningHours>>,
+  openingHours: {
+    Monday?: Array<OpeningHours>,
+    Tuesday?: Array<OpeningHours>,
+    Wednesday?: Array<OpeningHours>,
+    Thursday?: Array<OpeningHours>,
+    Friday?: Array<OpeningHours>,
+    Saturday?: Array<OpeningHours>,
+    Sunday?: Array<OpeningHours>
+  },
   latitude: string,
   longitude: string,
   description: string,
@@ -1431,7 +1439,15 @@ export const Location = t.type({
   telex: t.string,
   webUrl: t.string,
   email: t.string,
-  openingHours: t.record(DayOfWeek, t.array(OpeningHours)),
+  openingHours: t.partial({
+    Monday: t.array(OpeningHours),
+    Tuesday: t.array(OpeningHours),
+    Wednesday: t.array(OpeningHours),
+    Thursday: t.array(OpeningHours),
+    Friday: t.array(OpeningHours),
+    Saturday: t.array(OpeningHours),
+    Sunday: t.array(OpeningHours)
+  }),
   latitude: t.string,
   longitude: t.string,
   description: t.string,


### PR DESCRIPTION
Closes [#2521235](https://buildo.kaiten.io/space/[object Object]/card/2521235)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #94

Make the keys of a record optional in case the key type is an enum.

Given the following Scala code
```
case class Location(
  openingHours: Map[DayOfWeek, List[OpeningHours]]
)
```
where DayOfWeek is an `enum` that is generated as
 ```
type DayOfWeek = 'Monday' | 'Tuesday' | 'Wednesday' | 'Thursday' | 'Friday' | 'Saturday' | 'Sunday'
```
the generated code is now

```
export interface Location {
  openingHours: {
    Monday?: Array<OpeningHours>,
    Tuesday?: Array<OpeningHours>,
    Wednesday?: Array<OpeningHours>,
    Thursday?: Array<OpeningHours>,
    Friday?: Array<OpeningHours>,
    Saturday?: Array<OpeningHours>,
    Sunday?: Array<OpeningHours>
  }
}

export const Location = t.type({
  openingHours: t.partial({
    Monday: t.array(OpeningHours),
    Tuesday: t.array(OpeningHours),
    Wednesday: t.array(OpeningHours),
    Thursday: t.array(OpeningHours),
    Friday: t.array(OpeningHours),
    Saturday: t.array(OpeningHours),
    Sunday: t.array(OpeningHours)
  })
})
```

## Test Plan

`yarn test` runs successfully
