### PR TITLE
#98: missing Option and createOptionFromNullable imports in generated API file (closes #98)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,9 @@ export function getModels(models: Array<Model>, options: GetModelsOptions, prelu
   let out = [
     '// DO NOT EDIT MANUALLY - metarpheus-generated',
     "import * as t from 'io-ts'",
+    '// @ts-ignore',
     "import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'",
+    '// @ts-ignore',
     "import { Option } from 'fp-ts/lib/Option'",
     '',
     ''
@@ -423,7 +425,9 @@ import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import { failure } from 'io-ts/lib/PathReporter'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 import * as m from './model-ts'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,6 +423,8 @@ import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import { failure } from 'io-ts/lib/PathReporter'
+import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+import { Option } from 'fp-ts/lib/Option'
 import * as m from './model-ts'
 
 export interface RouteConfig {

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1795,6 +1795,8 @@ import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import { failure } from 'io-ts/lib/PathReporter'
+import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+import { Option } from 'fp-ts/lib/Option'
 import * as m from './model-ts'
 
 export interface RouteConfig {
@@ -2002,6 +2004,8 @@ import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import { failure } from 'io-ts/lib/PathReporter'
+import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+import { Option } from 'fp-ts/lib/Option'
 import * as m from './model-ts'
 
 export interface RouteConfig {

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`getModels should allow legacy newtype encoding 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 
 
@@ -39,7 +41,9 @@ export function externalIdIso<A>() { return iso<ExternalId<A>>() }
 exports[`getModels should handle any 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 
 export const VoidFromUnit = new t.Type<void, {}>(
@@ -69,7 +73,9 @@ export const NotificationPayload = t.type({
 exports[`getModels should return the models (source1) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 
 
@@ -658,7 +664,9 @@ export const ICQWorkcell = t.type({
 exports[`getModels should return the models in the right (source2) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 
 export const VoidFromUnit = new t.Type<void, {}>(
@@ -860,7 +868,9 @@ export const SortOrder = t.keyof({
 exports[`getModels should return the models in the right (source3) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 
 export const VoidFromUnit = new t.Type<void, {}>(
@@ -1472,7 +1482,9 @@ export const SelectedSpecialEquipment = t.type({
 exports[`getModels should return the models in the right (source4) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 
 
@@ -1795,7 +1807,9 @@ import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import { failure } from 'io-ts/lib/PathReporter'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 import * as m from './model-ts'
 
@@ -2004,7 +2018,9 @@ import { tryCatch, TaskEither } from 'fp-ts/lib/TaskEither'
 import { identity } from 'fp-ts/lib/function'
 import * as t from 'io-ts'
 import { failure } from 'io-ts/lib/PathReporter'
+// @ts-ignore
 import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
 import { Option } from 'fp-ts/lib/Option'
 import * as m from './model-ts'
 


### PR DESCRIPTION
Closes [#2522334](https://buildo.kaiten.io/space/[object Object]/card/2522334)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #98

Since I'm just blindly hardcoding the imports in generated files, a project with no `Option` usage and `noUnusedVariables: true` in tsconfig would fail compiling :/

For newtypes we are adding the prelude conditionally in the model file only (btw, I think ti would fail in the same way if the definition of the newtype is inlined in Scala and doesn't have an explicit name?), but it is a bit trickier to correctly compute this condition for `Option` usages since the majority of usages is inlined in Scala and we'd need to keep track of wether an `Option<T>` has never been generated at any level deep in the tree.

Any ideas?