### PR TITLE
#79: Add support for union types (closes #79)

### DIFF
--- a/output/source1.json
+++ b/output/source1.json
@@ -1,6 +1,7 @@
 {
   "models": [
     {
+      "_type": "CaseEnum",
       "name": "ReservationProfile",
       "values": [
         {
@@ -15,6 +16,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "SpecialEquipment",
       "values": [
         {
@@ -35,6 +37,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "Vendor",
       "values": [
         {
@@ -52,6 +55,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableRentalRate",
       "members": [
         {
@@ -69,6 +73,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableVehicleSearchQuery",
       "members": [
         {
@@ -116,6 +121,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableVehicleSearchResult",
       "members": [
         {
@@ -154,6 +160,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "LocationSearchResult",
       "members": [
         {
@@ -223,6 +230,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "VehicleAvailability",
       "members": [
         {
@@ -248,6 +256,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableSpecialEquipment",
       "members": [
         {
@@ -271,6 +280,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "Location",
       "members": [
         {
@@ -942,6 +952,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableFare",
       "members": [
         {
@@ -1010,6 +1021,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableVehicle",
       "members": [
         {
@@ -1051,6 +1063,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "PricedSpecialEquipment",
       "members": [
         {
@@ -1086,6 +1099,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "RentalRate",
       "members": [
         {
@@ -1137,6 +1151,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "RentalRateDistance",
       "members": [
         {
@@ -1176,6 +1191,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "RentalRateDistanceUnit",
       "values": [
         {
@@ -1190,6 +1206,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "RentalRateTotal",
       "members": [
         {
@@ -1207,6 +1224,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "SelectedSpecialEquipment",
       "members": [
         {
@@ -1224,6 +1242,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "Vehicle",
       "members": [
         {
@@ -1364,6 +1383,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleCategory",
       "values": [
         {
@@ -1432,6 +1452,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleDrive",
       "values": [
         {
@@ -1446,6 +1467,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleFuel",
       "values": [
         {
@@ -1478,6 +1500,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleSize",
       "values": [
         {
@@ -1544,6 +1567,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleTransmission",
       "values": [
         {
@@ -1555,6 +1579,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "CancellationPolicy",
       "values": [
         {
@@ -1563,6 +1588,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "PaymentMode",
       "values": [
         {

--- a/output/source1.json
+++ b/output/source1.json
@@ -1598,6 +1598,94 @@
           "name": "Prepaid"
         }
       ]
+    },
+    {
+      "name": "CreateCampingError",
+      "values": [
+        {
+          "name": "DuplicateName",
+          "params": [
+            {
+              "name": "names",
+              "tpe": {
+                "name": "SuggestedNames",
+                "_type": "Name"
+              },
+              "desc": "suggestions for names that are not in use"
+            }
+          ],
+          "desc": "The name is already in use",
+          "isValueClass": false
+        },
+        {
+          "name": "SizeOutOfBounds",
+          "params": [
+            {
+              "name": "min",
+              "tpe": {
+                "name": "Int",
+                "_type": "Name"
+              }
+            },
+            {
+              "name": "max",
+              "tpe": {
+                "name": "Int",
+                "_type": "Name"
+              }
+            }
+          ],
+          "desc": "The chosen size is not allowed",
+          "isValueClass": false
+        },
+        {
+          "name": "OtherError",
+          "params": [],
+          "isValueClass": false
+        }
+      ],
+      "desc": "Errors that can happen when creating a camping",
+      "_type": "TaggedUnion"
+    },
+    {
+      "name": "SuggestedNames",
+      "members": [
+        {
+          "name": "names",
+          "tpe": {
+            "name": "List",
+            "args": [
+              {
+                "name": "String",
+                "_type": "Name"
+              }
+            ],
+            "_type": "Apply"
+          }
+        }
+      ],
+      "isValueClass": false,
+      "typeParams": [],
+      "_type": "CaseClass"
+    },
+    {
+      "name": "Surface",
+      "values": [
+        {
+          "name": "Sand",
+          "params": [],
+          "desc": "Sandy",
+          "isValueClass": false
+        },
+        {
+          "name": "Earth",
+          "params": [],
+          "desc": "Dirt",
+          "isValueClass": false
+        }
+      ],
+      "desc": "Surface of the camping site",
+      "_type": "TaggedUnion"
     }
   ],
   "routes": [

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -10,6 +10,7 @@ export interface CaseClassMember {
 }
 
 export interface CaseClass {
+  _type: 'CaseClass';
   name: string;
   members: Array<CaseClassMember>;
   desc?: string;
@@ -17,16 +18,30 @@ export interface CaseClass {
   isValueClass: boolean;
 }
 
-export interface EnumClassValue {
+export interface EnumValue {
   name: string;
 }
 
-export interface EnumClass {
+export interface Enum {
+  _type: 'CaseEnum';
   name: string;
-  values: Array<EnumClassValue>;
+  values: Array<EnumValue>;
 }
 
-export type Model = CaseClass | EnumClass;
+export interface TaggedUnionValue {
+  name: string;
+  params: Array<CaseClassMember>;
+  desc?: string;
+  isValueClass: boolean;
+}
+
+export interface TaggedUnion {
+  _type: 'TaggedUnion';
+  name: string;
+  values: Array<TaggedUnionValue>;
+}
+
+export type Model = CaseClass | Enum | TaggedUnion;
 
 export interface RouteParam {
   name?: string;

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -70,6 +70,78 @@ export const NotificationPayload = t.type({
 "
 `;
 
+exports[`getModels should handle tagged union types 1`] = `
+"// DO NOT EDIT MANUALLY - metarpheus-generated
+import * as t from 'io-ts'
+// @ts-ignore
+import { createOptionFromNullable } from 'io-ts-types/lib/fp-ts/createOptionFromNullable'
+// @ts-ignore
+import { Option } from 'fp-ts/lib/Option'
+
+export const VoidFromUnit = new t.Type<void, {}>(
+  'VoidFromUnit',
+  (_m): _m is void => true,
+  () => t.success(undefined),
+  () => ({})
+)
+export interface SuggestedNames {
+  names: Array<string>
+}
+
+export const SuggestedNames = t.type({
+  names: t.array(t.string)
+}, 'SuggestedNames')
+
+export type CreateCampingError =
+  | {
+  /** suggestions for names that are not in use */
+  names: SuggestedNames,
+  _type: 'DuplicateName'
+}
+  | {
+  min: number,
+  max: number,
+  _type: 'SizeOutOfBounds'
+}
+  | {
+  _type: 'OtherError'
+}
+
+export const CreateCampingError = t.union([
+  t.type({
+    /** suggestions for names that are not in use */
+    names: SuggestedNames,
+    _type: t.literal('DuplicateName')
+  }, 'DuplicateName'),
+  t.type({
+    min: t.Integer,
+    max: t.Integer,
+    _type: t.literal('SizeOutOfBounds')
+  }, 'SizeOutOfBounds'),
+  t.type({
+    _type: t.literal('OtherError')
+  }, 'OtherError')
+], 'CreateCampingError')
+
+export type Surface =
+  | {
+  _type: 'Sand'
+}
+  | {
+  _type: 'Earth'
+}
+
+export const Surface = t.union([
+  t.type({
+    _type: t.literal('Sand')
+  }, 'Sand'),
+  t.type({
+    _type: t.literal('Earth')
+  }, 'Earth')
+], 'Surface')
+"
+`;
+
 exports[`getModels should return the models (source1) 1`] = `
 "// DO NOT EDIT MANUALLY - metarpheus-generated
 import * as t from 'io-ts'

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -46,6 +46,12 @@ describe('getModels', () => {
     const out = getModels(models, { isReadonly: false, runtime: true, useLegacyNewtype: true });
     expect(trimRight(out)).toMatchSnapshot();
   });
+
+  it('should handle tagged union types', () => {
+    const models: Array<Model> = require('./source-tagged-unions').models;
+    const out = getModels(models, { isReadonly: false, runtime: true, useLegacyNewtype: true });
+    expect(trimRight(out)).toMatchSnapshot();
+  });
 });
 
 describe('getRoutes', () => {

--- a/test/source-legacy-newtype.json
+++ b/test/source-legacy-newtype.json
@@ -1,6 +1,7 @@
 {
   "models" : [
     {
+      "_type": "CaseClass",
       "name" : "ExternalId",
       "members" : [
         {

--- a/test/source-tagged-unions.json
+++ b/test/source-tagged-unions.json
@@ -1,0 +1,92 @@
+{
+  "models" : [
+    {
+      "name": "CreateCampingError",
+      "values": [
+        {
+          "name": "DuplicateName",
+          "params": [
+            {
+              "name": "names",
+              "tpe": {
+                "name": "SuggestedNames",
+                "_type": "Name"
+              },
+              "desc": "suggestions for names that are not in use"
+            }
+          ],
+          "desc": "The name is already in use",
+          "isValueClass": false
+        },
+        {
+          "name": "SizeOutOfBounds",
+          "params": [
+            {
+              "name": "min",
+              "tpe": {
+                "name": "Int",
+                "_type": "Name"
+              }
+            },
+            {
+              "name": "max",
+              "tpe": {
+                "name": "Int",
+                "_type": "Name"
+              }
+            }
+          ],
+          "desc": "The chosen size is not allowed",
+          "isValueClass": false
+        },
+        {
+          "name": "OtherError",
+          "params": [],
+          "isValueClass": false
+        }
+      ],
+      "desc": "Errors that can happen when creating a camping",
+      "_type": "TaggedUnion"
+    },
+    {
+      "name": "SuggestedNames",
+      "members": [
+        {
+          "name": "names",
+          "tpe": {
+            "name": "List",
+            "args": [
+              {
+                "name": "String",
+                "_type": "Name"
+              }
+            ],
+            "_type": "Apply"
+          }
+        }
+      ],
+      "isValueClass": false,
+      "typeParams": [],
+      "_type": "CaseClass"
+    },
+    {
+      "name": "Surface",
+      "values": [
+        {
+          "name": "Sand",
+          "params": [],
+          "desc": "Sandy",
+          "isValueClass": false
+        },
+        {
+          "name": "Earth",
+          "params": [],
+          "desc": "Dirt",
+          "isValueClass": false
+        }
+      ],
+      "desc": "Surface of the camping site",
+      "_type": "TaggedUnion"
+    }
+  ]
+}

--- a/test/source1.json
+++ b/test/source1.json
@@ -1,6 +1,7 @@
 {
   "models": [
     {
+      "_type": "CaseClass",
       "name": "HealthId",
       "members": [
         {
@@ -13,6 +14,7 @@
       "isValueClass": true
     },
     {
+      "_type": "CaseClass",
       "name": "Health",
       "members": [
         {
@@ -40,6 +42,7 @@
       "desc": "Health"
     },
     {
+      "_type": "CaseClass",
       "name": "ICQAlert",
       "members": [
         {
@@ -104,6 +107,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQAlertCategory",
       "values": [
         {
@@ -118,6 +122,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "ICQAssayReference",
       "members": [
         {
@@ -135,6 +140,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "ICQCalibration",
       "members": [
         {
@@ -239,6 +245,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQCalibrationMethod",
       "values": [
         {
@@ -307,6 +314,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQCalibrationType",
       "values": [
         {
@@ -318,6 +326,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQCalibrationStatus",
       "values": [
         {
@@ -347,6 +356,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "ICQOnBoardSolution",
       "members": [
         {
@@ -457,6 +467,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "ICQProcessingModule",
       "members": [
         {
@@ -534,6 +545,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQModuleType",
       "values": [
         {
@@ -545,6 +557,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQModuleStatus",
       "values": [
         {
@@ -577,6 +590,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQOverallStatus",
       "values": [
         {
@@ -591,6 +605,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "ICQQCAnalysis",
       "members": [
         {
@@ -656,6 +671,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQQCAnalysisStatus",
       "values": [
         {
@@ -673,6 +689,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "ICQQCMaterial",
       "members": [
         {
@@ -817,6 +834,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQQCMaterialStatus",
       "values": [
         {
@@ -837,6 +855,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQReagentStatus",
       "values": [
         {
@@ -887,6 +906,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQReagentCartridgeStatus",
       "values": [
         {
@@ -919,6 +939,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "ICQRSM",
       "members": [
         {
@@ -948,6 +969,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQRSMStatus",
       "values": [
         {
@@ -974,6 +996,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "ICQWorkcell",
       "members": [
         {
@@ -1056,6 +1079,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQConnectionStatus",
       "values": [
         {
@@ -1070,6 +1094,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ICQPrinterStatus",
       "values": [
         {
@@ -1087,6 +1112,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "Camping",
       "members": [
         {
@@ -1114,6 +1140,7 @@
       "desc": "Represents a camping site"
     },
     {
+      "_type": "CaseEnum",
       "name": "CampingLocation",
       "values": [
         {

--- a/test/source2.json
+++ b/test/source2.json
@@ -1,6 +1,7 @@
 {
   "models": [
     {
+      "_type": "CaseEnum",
       "name": "ReservationProfile",
       "values": [
         {
@@ -15,6 +16,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "SortOrder",
       "values": [
         {
@@ -26,6 +28,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "Vendor",
       "values": [
         {
@@ -43,6 +46,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AgencySearchResult",
       "members": [
         {
@@ -70,6 +74,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "NationSearchResult",
       "members": [
         {
@@ -108,6 +113,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "CancellationPolicy",
       "values": [
         {
@@ -116,6 +122,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "Fare",
       "members": [
         {
@@ -213,6 +220,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "NewFare",
       "members": [
         {
@@ -309,6 +317,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "FareRule",
       "members": [
         {
@@ -380,6 +389,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "FareSummary",
       "members": [
         {
@@ -421,6 +431,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "FareSummarySorting",
       "values": [
         {
@@ -438,6 +449,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "PaymentMode",
       "values": [
         {
@@ -449,6 +461,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "Tag",
       "members": [
         {

--- a/test/source3.json
+++ b/test/source3.json
@@ -1,6 +1,7 @@
 {
   "models": [
     {
+      "_type": "CaseEnum",
       "name": "DayOfWeek",
       "values": [
         {
@@ -27,6 +28,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "OpeningHours",
       "members": [
         {
@@ -44,6 +46,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "ReservationProfile",
       "values": [
         {
@@ -58,6 +61,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "SpecialEquipment",
       "values": [
         {
@@ -78,6 +82,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "Vendor",
       "values": [
         {
@@ -95,6 +100,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableRentalRate",
       "members": [
         {
@@ -112,6 +118,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableVehicleSearchQuery",
       "members": [
         {
@@ -159,6 +166,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableVehicleSearchResult",
       "members": [
         {
@@ -197,6 +205,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "LocationSearchResult",
       "members": [
         {
@@ -266,6 +275,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "VehicleAvailability",
       "members": [
         {
@@ -291,6 +301,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableSpecialEquipment",
       "members": [
         {
@@ -314,6 +325,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "Location",
       "members": [
         {
@@ -752,6 +764,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableFare",
       "members": [
         {
@@ -820,6 +833,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "AvailableVehicle",
       "members": [
         {
@@ -861,6 +875,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "PricedSpecialEquipment",
       "members": [
         {
@@ -896,6 +911,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "RentalRate",
       "members": [
         {
@@ -947,6 +963,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "RentalRateDistance",
       "members": [
         {
@@ -986,6 +1003,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "RentalRateDistanceUnit",
       "values": [
         {
@@ -1000,6 +1018,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "RentalRateTotal",
       "members": [
         {
@@ -1017,6 +1036,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "SelectedSpecialEquipment",
       "members": [
         {
@@ -1034,6 +1054,7 @@
       ]
     },
     {
+      "_type": "CaseClass",
       "name": "Vehicle",
       "members": [
         {
@@ -1174,6 +1195,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleCategory",
       "values": [
         {
@@ -1242,6 +1264,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleDrive",
       "values": [
         {
@@ -1256,6 +1279,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleFuel",
       "values": [
         {
@@ -1288,6 +1312,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleSize",
       "values": [
         {
@@ -1354,6 +1379,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "VehicleTransmission",
       "values": [
         {
@@ -1365,6 +1391,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "CancellationPolicy",
       "values": [
         {
@@ -1373,6 +1400,7 @@
       ]
     },
     {
+      "_type": "CaseEnum",
       "name": "PaymentMode",
       "values": [
         {

--- a/test/source4.json
+++ b/test/source4.json
@@ -1,5 +1,6 @@
 {
   "models" : [ {
+    "_type": "CaseClass",
     "name" : "TemperaturePoint",
     "members" : [ {
       "name" : "linearPositionIndex",
@@ -20,6 +21,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "ExternalSemiconductiveLayer",
     "members" : [ {
       "name" : "unwrap",
@@ -30,6 +32,7 @@
     "isValueClass" : true,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "ConductorLayer",
     "members" : [ {
       "name" : "unwrap",
@@ -40,6 +43,7 @@
     "isValueClass" : true,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "ExternalId",
     "members" : [ {
       "name" : "unwrap",
@@ -52,6 +56,7 @@
       "name" : "A"
     } ]
   }, {
+    "_type": "CaseEnum",
     "name" : "Role",
     "values" : [ {
       "name" : "Admin"
@@ -59,6 +64,7 @@
       "name" : "User"
     } ]
   }, {
+    "_type": "CaseClass",
     "name" : "Id",
     "members" : [ {
       "name" : "unwrap",
@@ -71,6 +77,7 @@
       "name" : "A"
     } ]
   }, {
+    "_type": "CaseClass",
     "name" : "CalculationRun",
     "members" : [ {
       "name" : "conductorMaxTemperature",
@@ -157,6 +164,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "Entity",
     "members" : [ {
       "name" : "id",
@@ -177,6 +185,7 @@
       "name" : "A"
     } ]
   }, {
+    "_type": "CaseClass",
     "name" : "VolumetricSpecificHeat",
     "members" : [ {
       "name" : "temperature",
@@ -192,6 +201,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "InsulationLayer",
     "members" : [ {
       "name" : "unwrap",
@@ -202,6 +212,7 @@
     "isValueClass" : true,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "User",
     "members" : [ {
       "name" : "externalId",
@@ -228,6 +239,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "Zone",
     "members" : [ {
       "name" : "type",
@@ -283,6 +295,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "ActivationEnergy",
     "members" : [ {
       "name" : "temperature",
@@ -298,6 +311,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "Material",
     "members" : [ {
       "name" : "volumetricSpecificHeatMap",
@@ -335,6 +349,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseEnum",
     "name" : "ZoneType",
     "values" : [ {
       "name" : "Air"
@@ -360,6 +375,7 @@
       "name" : "Flange"
     } ]
   }, {
+    "_type": "CaseClass",
     "name" : "CalculationInput",
     "members" : [ {
       "name" : "name",
@@ -449,6 +465,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "ThermalResistivity",
     "members" : [ {
       "name" : "temperature",
@@ -464,6 +481,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "CalculationOutput",
     "members" : [ {
       "name" : "lineSpeeds",
@@ -485,6 +503,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "Layer",
     "members" : [ {
       "name" : "discretisationLayers",
@@ -513,6 +532,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "CrossLinksFormationTime",
     "members" : [ {
       "name" : "temperature",
@@ -528,6 +548,7 @@
     "isValueClass" : false,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "InternalSemiconductiveLayer",
     "members" : [ {
       "name" : "unwrap",
@@ -538,6 +559,7 @@
     "isValueClass" : true,
     "typeParams" : [ ]
   }, {
+    "_type": "CaseClass",
     "name" : "CrossLinkingPoint",
     "members" : [ {
       "name" : "linearPositionIndex",


### PR DESCRIPTION
Closes [#2521130](https://buildo.kaiten.io/space/[object Object]/card/2521130)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #79

Generates TypeScript union types from the metarpheus model with tagged union types ([retro PR](https://github.com/buildo/retro/pull/62)), using a `_type` field to make the unions discriminated.

### Notes

- Based on the `v1` branch, not on `master`.
- The [retro PR](https://github.com/buildo/retro/pull/62) also adds a field to routes to describe the type of errors they can produce. I didn't deal with it for now. This means that metarpheus-io-ts will generate TypeScript types for the error models produced by metarpheus and these will be unused until we change code generation for routes to handle them (I'm not sure how).
- In the metarpheus model, values in tagged unions can be marked `isValueClass` or not, but I'm not using it (I'm not sure if it makes any sense to use it).

## Test Plan

I've added two tagged union models to the tests taking them from those in retro. They test tagged union values both with and without parameters.