### PR TITLE
#103: Remove `isReadonly` (closes #103)

### DIFF
--- a/output/index.ts
+++ b/output/index.ts
@@ -18,8 +18,8 @@ sourceFileNames.forEach(sourceFileName => {
   const source = require(resolve(__dirname, sourceFileName));
   const modelsSource: Array<Model> = source.models;
   const routesSource: Array<Route> = source.routes;
-  const modelsOutput = getModels(modelsSource, { isReadonly: false, runtime: true, useLegacyNewtype: false });
-  const routesOutput = getRoutes(routesSource, modelsSource, { isReadonly: false });
+  const modelsOutput = getModels(modelsSource, { runtime: true, useLegacyNewtype: false });
+  const routesOutput = getRoutes(routesSource, modelsSource);
   const dir = resolve(__dirname, `${sourceFileName}.dir`);
   fs.mkdirSync(dir);
   fs.writeFileSync(resolve(dir, 'model-ts.ts'), modelsOutput);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,7 @@ if (program.out) {
 
 const routes: Array<Route> = source.routes;
 
-const routesOut = getRoutes(routes, source.models, { isReadonly: !!program.readonly });
+const routesOut = getRoutes(routes, source.models);
 
 if (program.out) {
   fs.writeFileSync(path.resolve(process.cwd(), `${program.out}-routes.ts`), routesOut, { encoding });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ import { contramap, ordString } from 'fp-ts/lib/Ord';
 interface Ctx {
   models: Array<Model>;
   prefix: string;
-  isReadonly: boolean;
   useLegacyNewtype: boolean;
 }
 
@@ -64,7 +63,7 @@ function optionCombinator(tpe: Tpe): Reader<Ctx, gen.CustomCombinator> {
 }
 
 export function getType(tpe: Tpe): Reader<Ctx, gen.TypeReference> {
-  return ask<Ctx>().chain<gen.TypeReference>(({ prefix, isReadonly }) => {
+  return ask<Ctx>().chain<gen.TypeReference>(({ prefix }) => {
     switch (tpe.name) {
       case 'String':
         return reader.of(gen.stringType);
@@ -86,9 +85,7 @@ export function getType(tpe: Tpe): Reader<Ctx, gen.TypeReference> {
       case 'List':
       case 'Set':
       case 'TreeSet':
-        return isReadonly
-          ? getType(tpe.args![0]).map(gen.readonlyArrayCombinator)
-          : getType(tpe.args![0]).map(gen.arrayCombinator);
+        return getType(tpe.args![0]).map(gen.arrayCombinator);
       case 'Map':
         return getType(tpe.args![0]).chain(keyType =>
           getType(tpe.args![1]).map(valueType => gen.recordCombinator(keyType, valueType))
@@ -103,7 +100,6 @@ export function getType(tpe: Tpe): Reader<Ctx, gen.TypeReference> {
 }
 
 export interface GetModelsOptions {
-  isReadonly: boolean;
   runtime: boolean;
   useLegacyNewtype?: boolean;
 }
@@ -150,28 +146,26 @@ function getCaseClassDeclaration(caseClass: CaseClass): Reader<Ctx, gen.TypeDecl
   if (caseClass.isValueClass) {
     return getNewtype(caseClass);
   }
-  return ask<Ctx>().chain(({ isReadonly }) =>
-    traverseReader(caseClass.members, getProperty).map(properties => {
-      const interfaceDecl = gen.typeCombinator(properties, caseClass.name);
-      if (caseClass.typeParams && caseClass.typeParams.length > 0) {
-        const staticParams = caseClass.typeParams.map(p => `${p.name} extends t.Any`).join(', ');
-        const runtimeParams = caseClass.typeParams.map(p => `${p.name}: ${p.name}`).join(', ');
-        const dependencies = interfaceDecl.properties
-          .map(p => gen.printStatic(p.type))
-          .filter(p => !caseClass.typeParams.map(p => p.name).includes(p));
-        return gen.customTypeDeclaration(
-          caseClass.name,
-          `export interface ${caseClass.name}<${caseClass.typeParams.map(p => p.name)}> ${gen.printStatic(
-            interfaceDecl
-          )}`,
-          `export const ${caseClass.name} = <${staticParams}>(${runtimeParams}) => ${gen.printRuntime(interfaceDecl)}`,
-          dependencies
-        );
-      } else {
-        return gen.typeDeclaration(caseClass.name, interfaceDecl, true, isReadonly);
-      }
-    })
-  );
+  return traverseReader(caseClass.members, getProperty).map(properties => {
+    const interfaceDecl = gen.typeCombinator(properties, caseClass.name);
+    if (caseClass.typeParams && caseClass.typeParams.length > 0) {
+      const staticParams = caseClass.typeParams.map(p => `${p.name} extends t.Any`).join(', ');
+      const runtimeParams = caseClass.typeParams.map(p => `${p.name}: ${p.name}`).join(', ');
+      const dependencies = interfaceDecl.properties
+        .map(p => gen.printStatic(p.type))
+        .filter(p => !caseClass.typeParams.map(p => p.name).includes(p));
+      return gen.customTypeDeclaration(
+        caseClass.name,
+        `export interface ${caseClass.name}<${caseClass.typeParams.map(p => p.name)}> ${gen.printStatic(
+          interfaceDecl
+        )}`,
+        `export const ${caseClass.name} = <${staticParams}>(${runtimeParams}) => ${gen.printRuntime(interfaceDecl)}`,
+        dependencies
+      );
+    } else {
+      return gen.typeDeclaration(caseClass.name, interfaceDecl, true, false);
+    }
+  });
 }
 
 function getEnumDeclaration(enumModel: Enum): Reader<Ctx, gen.TypeDeclaration | gen.CustomTypeDeclaration> {
@@ -244,7 +238,6 @@ export function getModels(models: Array<Model>, options: GetModelsOptions, prelu
   const declarations = getDeclarations(models).run({
     models,
     prefix: '',
-    isReadonly: options.isReadonly,
     useLegacyNewtype: options.useLegacyNewtype || false
   });
   const hasNewtypeDeclarations = models.some(m => 'isValueClass' in m && m.isValueClass);
@@ -272,10 +265,6 @@ export function getModels(models: Array<Model>, options: GetModelsOptions, prelu
     })
     .join('\n\n');
   return out;
-}
-
-export interface GetRoutesOptions {
-  isReadonly: boolean;
 }
 
 function isRouteSegmentString(routeSegment: RouteSegment): routeSegment is RouteSegmentString {
@@ -459,23 +448,14 @@ export interface RouteConfig {
 }
 `;
 
-export function getRoutes(
-  routes: Array<Route>,
-  models: Array<Model>,
-  options: GetRoutesOptions,
-  prelude: string = getRoutesPrelude
-): string {
+export function getRoutes(routes: Array<Route>, models: Array<Model>, prelude: string = getRoutesPrelude): string {
   return (
     prelude +
     `
 export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
   return {
 ` +
-    routes
-      .map(route =>
-        getRoute(route).run({ models, prefix: 'm.', isReadonly: options.isReadonly, useLegacyNewtype: false })
-      )
-      .join(',\n\n') +
+    routes.map(route => getRoute(route).run({ models, prefix: 'm.', useLegacyNewtype: false })).join(',\n\n') +
     `
   }
 }`

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -747,25 +747,25 @@ export const VoidFromUnit = new t.Type<void, {}>(
   () => t.success(undefined),
   () => ({})
 )
-export type Tag = Readonly<{
+export interface Tag {
   id: UUID,
   label: string
-}>
+}
 
-export const Tag = t.readonly(t.type({
+export const Tag = t.type({
   id: UUID,
   label: t.string
-}, 'Tag'), 'Tag')
+}, 'Tag')
 
-export type AgencySearchResult = Readonly<{
-  agencies: ReadonlyArray<Tag>,
-  networks: ReadonlyArray<Tag>
-}>
+export interface AgencySearchResult {
+  agencies: Array<Tag>,
+  networks: Array<Tag>
+}
 
-export const AgencySearchResult = t.readonly(t.type({
-  agencies: t.readonlyArray(Tag),
-  networks: t.readonlyArray(Tag)
-}, 'AgencySearchResult'), 'AgencySearchResult')
+export const AgencySearchResult = t.type({
+  agencies: t.array(Tag),
+  networks: t.array(Tag)
+}, 'AgencySearchResult')
 
 export type CancellationPolicy =
   | 'Free'
@@ -796,25 +796,25 @@ export const PaymentMode = t.keyof({
   Prepaid: null
 }, 'PaymentMode')
 
-export type FareRule = Readonly<{
+export interface FareRule {
   pickUpValidFrom: Option<LocalDate>,
   pickUpValidUntil: Option<LocalDate>,
   reservationValidFrom: Option<LocalDate>,
   reservationValidUntil: Option<LocalDate>,
-  nations: ReadonlyArray<Tag>,
-  agencies: ReadonlyArray<Tag>
-}>
+  nations: Array<Tag>,
+  agencies: Array<Tag>
+}
 
-export const FareRule = t.readonly(t.type({
+export const FareRule = t.type({
   pickUpValidFrom: createOptionFromNullable(LocalDate),
   pickUpValidUntil: createOptionFromNullable(LocalDate),
   reservationValidFrom: createOptionFromNullable(LocalDate),
   reservationValidUntil: createOptionFromNullable(LocalDate),
-  nations: t.readonlyArray(Tag),
-  agencies: t.readonlyArray(Tag)
-}, 'FareRule'), 'FareRule')
+  nations: t.array(Tag),
+  agencies: t.array(Tag)
+}, 'FareRule')
 
-export type Fare = Readonly<{
+export interface Fare {
   id: UUID,
   name: string,
   vendor: Vendor,
@@ -826,10 +826,10 @@ export type Fare = Readonly<{
   cancellationPolicy: CancellationPolicy,
   description: string,
   disabled: boolean,
-  rules: ReadonlyArray<FareRule>
-}>
+  rules: Array<FareRule>
+}
 
-export const Fare = t.readonly(t.type({
+export const Fare = t.type({
   id: UUID,
   name: t.string,
   vendor: Vendor,
@@ -841,8 +841,8 @@ export const Fare = t.readonly(t.type({
   cancellationPolicy: CancellationPolicy,
   description: t.string,
   disabled: t.boolean,
-  rules: t.readonlyArray(FareRule)
-}, 'Fare'), 'Fare')
+  rules: t.array(FareRule)
+}, 'Fare')
 
 export type ReservationProfile =
   | 'Leisure'
@@ -855,23 +855,23 @@ export const ReservationProfile = t.keyof({
   TourOperator: null
 }, 'ReservationProfile')
 
-export type FareSummary = Readonly<{
+export interface FareSummary {
   id: UUID,
   reservationProfile: ReservationProfile,
   name: string,
   vendor: Vendor,
   paymentMode: PaymentMode,
   disabled: boolean
-}>
+}
 
-export const FareSummary = t.readonly(t.type({
+export const FareSummary = t.type({
   id: UUID,
   reservationProfile: ReservationProfile,
   name: t.string,
   vendor: Vendor,
   paymentMode: PaymentMode,
   disabled: t.boolean
-}, 'FareSummary'), 'FareSummary')
+}, 'FareSummary')
 
 export type FareSummarySorting =
   | 'Name'
@@ -886,19 +886,19 @@ export const FareSummarySorting = t.keyof({
   Disabled: null
 }, 'FareSummarySorting')
 
-export type NationSearchResult = Readonly<{
-  regions: ReadonlyArray<Tag>,
-  countries: ReadonlyArray<Tag>,
-  states: ReadonlyArray<Tag>
-}>
+export interface NationSearchResult {
+  regions: Array<Tag>,
+  countries: Array<Tag>,
+  states: Array<Tag>
+}
 
-export const NationSearchResult = t.readonly(t.type({
-  regions: t.readonlyArray(Tag),
-  countries: t.readonlyArray(Tag),
-  states: t.readonlyArray(Tag)
-}, 'NationSearchResult'), 'NationSearchResult')
+export const NationSearchResult = t.type({
+  regions: t.array(Tag),
+  countries: t.array(Tag),
+  states: t.array(Tag)
+}, 'NationSearchResult')
 
-export type NewFare = Readonly<{
+export interface NewFare {
   name: string,
   vendor: Vendor,
   paymentMode: PaymentMode,
@@ -909,10 +909,10 @@ export type NewFare = Readonly<{
   cancellationPolicy: CancellationPolicy,
   description: string,
   disabled: boolean,
-  rules: ReadonlyArray<Option<FareRule>>
-}>
+  rules: Array<Option<FareRule>>
+}
 
-export const NewFare = t.readonly(t.type({
+export const NewFare = t.type({
   name: t.string,
   vendor: Vendor,
   paymentMode: PaymentMode,
@@ -923,8 +923,8 @@ export const NewFare = t.readonly(t.type({
   cancellationPolicy: CancellationPolicy,
   description: t.string,
   disabled: t.boolean,
-  rules: t.readonlyArray(createOptionFromNullable(FareRule))
-}, 'NewFare'), 'NewFare')
+  rules: t.array(createOptionFromNullable(FareRule))
+}, 'NewFare')
 
 export type SortOrder =
   | 'Ascending'

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -13,43 +13,43 @@ function trimRight(s: string): string {
 describe('getModels', () => {
   it('should return the models (source1)', () => {
     const models: Array<Model> = require('./source1.json').models;
-    const out = getModels(models, { isReadonly: false, runtime: true, useLegacyNewtype: false });
+    const out = getModels(models, { runtime: true, useLegacyNewtype: false });
     expect(trimRight(out)).toMatchSnapshot();
   });
 
   it('should return the models in the right (source2)', () => {
     const models: Array<Model> = require('./source2.json').models;
-    const out = getModels(models, { isReadonly: true, runtime: true, useLegacyNewtype: false });
+    const out = getModels(models, { runtime: true, useLegacyNewtype: false });
     expect(trimRight(out)).toMatchSnapshot();
   });
 
   it('should return the models in the right (source3)', () => {
     const models: Array<Model> = require('./source3.json').models;
-    const out = getModels(models, { isReadonly: false, runtime: true, useLegacyNewtype: false });
+    const out = getModels(models, { runtime: true, useLegacyNewtype: false });
     expect(trimRight(out)).toMatchSnapshot();
   });
 
   it('should return the models in the right (source4)', () => {
     const models: Array<Model> = require('./source4.json').models;
-    const out = getModels(models, { isReadonly: false, runtime: true, useLegacyNewtype: false });
+    const out = getModels(models, { runtime: true, useLegacyNewtype: false });
     expect(trimRight(out)).toMatchSnapshot();
   });
 
   it('should handle any', () => {
     const models: Array<Model> = require('./source-any.json').models;
-    const out = getModels(models, { isReadonly: false, runtime: true, useLegacyNewtype: false });
+    const out = getModels(models, { runtime: true, useLegacyNewtype: false });
     expect(trimRight(out)).toMatchSnapshot();
   });
 
   it('should allow legacy newtype encoding', () => {
     const models: Array<Model> = require('./source-legacy-newtype').models;
-    const out = getModels(models, { isReadonly: false, runtime: true, useLegacyNewtype: true });
+    const out = getModels(models, { runtime: true, useLegacyNewtype: true });
     expect(trimRight(out)).toMatchSnapshot();
   });
 
   it('should handle tagged union types', () => {
     const models: Array<Model> = require('./source-tagged-unions').models;
-    const out = getModels(models, { isReadonly: false, runtime: true, useLegacyNewtype: true });
+    const out = getModels(models, { runtime: true, useLegacyNewtype: true });
     expect(trimRight(out)).toMatchSnapshot();
   });
 });
@@ -58,14 +58,14 @@ describe('getRoutes', () => {
   it('should return the routes in the right (source3)', () => {
     const routes: Array<Route> = require('./source3.json').routes;
     const models: Array<Model> = require('./source3.json').models;
-    const out = getRoutes(routes, models, { isReadonly: false });
+    const out = getRoutes(routes, models);
     expect(trimRight(out)).toMatchSnapshot();
   });
 
   it('should return the routes in the right (source4)', () => {
     const routes: Array<Route> = require('./source4.json').routes;
     const models: Array<Model> = require('./source4.json').models;
-    const out = getRoutes(routes, models, { isReadonly: false });
+    const out = getRoutes(routes, models);
     expect(trimRight(out)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Closes [#2521129](https://buildo.kaiten.io/space/[object Object]/card/2521129)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #103

- Remove use of `isReadonly` in generation for case classes
- Remove use of `isReadonly` to choose between `array` and `readonlyArray`
- Remove `isReadonly` from `GetModelsOptions`
- Remove `GetRoutesOptions` completely since `isReadonly` was its only field

## Test Plan

I've re-ran the automatic tests and checked the diff in the snapshots.