### PR TITLE
#109: `genericCombinator` is mixing runtime and static type parameters when newtypes are involved (closes #109)

### DIFF
--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1624,7 +1624,7 @@ export const Layer = t.type({
   discretisationLayers: t.Integer,
   externalDiameter: t.number,
   initialTemperature: t.number,
-  materialId: Id<Material>()
+  materialId: Id<t.TypeOf<typeof Material>>()
 }, 'Layer')
 
 export interface ConductorLayer extends Newtype<{ readonly ConductorLayer: unique symbol }, Layer> {}
@@ -1821,8 +1821,8 @@ export interface Entity<A> {
   value: A
 }
 
-export const Entity = <A extends t.Any>(A: A) => t.type({
-  id: Id<A>(),
+export const Entity = <A extends t.Mixed>(A: A) => t.type({
+  id: Id<t.TypeOf<typeof A>>(),
   value: A
 }, 'Entity')
 
@@ -1881,7 +1881,7 @@ export interface User {
 }
 
 export const User = t.type({
-  externalId: ExternalId<User>(),
+  externalId: ExternalId<t.TypeOf<typeof User>>(),
   role: Role,
   fullName: createOptionFromNullable(t.string)
 }, 'User')
@@ -2188,7 +2188,7 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         method: 'get',
         url: \`\${_metarpheusRouteConfig.apiEndpoint}/user/read\`,
         params: {
-          id: m.Id<m.User>().encode(id)
+          id: m.Id<t.TypeOf<typeof m.User>>().encode(id)
         },
         data: {
 
@@ -2224,7 +2224,7 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
         },
         timeout: _metarpheusRouteConfig.timeout
       }), identity).chain(res =>
-              fromEither(m.Id<m.User>().decode(res.data))
+              fromEither(m.Id<t.TypeOf<typeof m.User>>().decode(res.data))
             )
     },
 
@@ -2255,7 +2255,7 @@ export default function getRoutes(_metarpheusRouteConfig: RouteConfig) {
 
         },
         data: {
-          id: m.Id<m.User>().encode(id)
+          id: m.Id<t.TypeOf<typeof m.User>>().encode(id)
         },
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
Closes [#2521056](https://buildo.kaiten.io/space/[object Object]/card/2521056)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).


Closes #109

## Test Plan

### tests performed

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.

### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.
