### PR TITLE
Fixing some security advisories by updating deps (closes #112)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "commander": "^2.9.0",
     "fp-ts": "^1.19.5",
     "io-ts-codegen": "0.3.3",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@types/jest": "^23.3.10",
-    "@types/lodash": "^4.14.76",
+    "@types/lodash": "^4.14.141",
     "@types/node": "7.0.4",
-    "axios": "^0.17.1",
+    "axios": "^0.19.0",
     "io-ts": "^1.8.5",
     "io-ts-types": "^0.4.7",
     "jest": "^23.6.0",


### PR DESCRIPTION
Closes [#2521027](https://buildo.kaiten.io/space/[object Object]/card/2521027)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #112 

Tests pass:
![image](https://user-images.githubusercontent.com/6418684/65870298-3370ef80-e37c-11e9-8a00-aa7b82918f48.png)
