### PR TITLE
#115: Handle tagged unions with fewer than two cases (closes #115)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,10 @@ function getEnumDeclaration(enumModel: Enum): Reader<Ctx, gen.TypeDeclaration | 
   return reader.of(
     gen.typeDeclaration(
       enumModel.name,
-      gen.keyofCombinator(enumModel.values.map(v => v.name), enumModel.name),
+      gen.keyofCombinator(
+        enumModel.values.map(v => v.name),
+        enumModel.name
+      ),
       true,
       false
     )

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -123,6 +123,18 @@ export const CreateCampingError = t.union([
   }, 'OtherError')
 ], 'CreateCampingError')
 
+export interface SingleCaseTaggedUnion {
+  x: number,
+  y: string,
+  _type: 'SingleCase'
+}
+
+export const SingleCaseTaggedUnion = t.type({
+  x: t.Integer,
+  y: t.string,
+  _type: t.literal('SingleCase')
+}, 'SingleCase')
+
 export type Surface =
   | {
   _type: 'Sand'

--- a/test/source-tagged-unions.json
+++ b/test/source-tagged-unions.json
@@ -87,6 +87,40 @@
       ],
       "desc": "Surface of the camping site",
       "_type": "TaggedUnion"
+    },
+    {
+      "name": "SingleCaseTaggedUnion",
+      "values": [
+        {
+          "name": "SingleCase",
+          "params": [
+            {
+              "name": "x",
+              "tpe": {
+                "name": "Int",
+                "_type": "Name"
+              }
+            },
+            {
+              "name": "y",
+              "tpe": {
+                "name": "String",
+                "_type": "Name"
+              }
+            }
+          ],
+          "desc": "Its only case",
+          "isValueClass": false
+        }
+      ],
+      "desc": "Not really much of a union",
+      "_type": "TaggedUnion"
+    },
+    {
+      "name": "ZeroCaseTaggedUnion",
+      "values": [],
+      "desc": "Nothing at all in here",
+      "_type": "TaggedUnion"
     }
   ]
 }


### PR DESCRIPTION
Closes [#2520856](https://buildo.kaiten.io/space/[object Object]/card/2520856)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #115

- Single-case tagged unions are now converted simply to interface declarations like
    ```typescript
    export interface SingleCaseTaggedUnion {
      x: number,
      y: string,
      _type: 'SingleCase'
    }

    export const SingleCaseTaggedUnion = t.type({
      x: t.Integer,
      y: t.string,
      _type: t.literal('SingleCase')
    }, 'SingleCase')
    ```
    without the erroneous union combinator.

- Zero-case tagged unions are just skipped in the output.

    The rationale for this is that they're not really useful right now for us because we're not generating precise types for errors (the left side of route `TaskEither`s) and zero-case tagged unions only make sense in the error type, not in the main route type or as field of another module.

    To move to more precise error handling, we should change this to output these types as synonyms for `never`, with an appropriate codec (perhaps one that always fails, probably actually anything that typechecks is fine since it won't be used).

## Test Plan

- Added 0- and 1-case tagged unions to the snapshot test
- Tested on metarpheus output on an internal project